### PR TITLE
fix(Display): waitForEnterメソッドでEnterキーのみに反応するように修正

### DIFF
--- a/src/ui/Display.test.ts
+++ b/src/ui/Display.test.ts
@@ -7,19 +7,22 @@ import { Display } from './Display';
 // Console出力をモック
 const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
 const processStdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
-const processStdinSpy = jest.spyOn(process.stdin, 'once');
+const processStdinOnSpy = jest.spyOn(process.stdin, 'on');
+const processStdinRemoveListenerSpy = jest.spyOn(process.stdin, 'removeListener');
 
 describe('Display', () => {
   beforeEach(() => {
     consoleSpy.mockClear();
     processStdoutSpy.mockClear();
-    processStdinSpy.mockClear();
+    processStdinOnSpy.mockClear();
+    processStdinRemoveListenerSpy.mockClear();
   });
 
   afterAll(() => {
     consoleSpy.mockRestore();
     processStdoutSpy.mockRestore();
-    processStdinSpy.mockRestore();
+    processStdinOnSpy.mockRestore();
+    processStdinRemoveListenerSpy.mockRestore();
   });
 
   describe('clear', () => {
@@ -138,12 +141,13 @@ describe('Display', () => {
 
   describe('waitForEnter', () => {
     it('デフォルトメッセージでEnterキーを待つ', async () => {
-      processStdinSpy.mockImplementation((event: string, callback: () => void) => {
+      processStdinOnSpy.mockImplementation((event: string, callback: (data: Buffer) => void) => {
         if (event === 'data') {
-          setTimeout(() => callback(), 0);
+          setTimeout(() => callback(Buffer.from('\n')), 0);
         }
         return process.stdin;
       });
+      processStdinRemoveListenerSpy.mockImplementation(() => process.stdin);
 
       const promise = Display.waitForEnter();
       await promise;
@@ -151,17 +155,18 @@ describe('Display', () => {
       expect(processStdoutSpy).toHaveBeenCalledWith(
         expect.stringContaining('Press Enter to continue')
       );
-      expect(processStdinSpy).toHaveBeenCalledWith('data', expect.any(Function));
+      expect(processStdinOnSpy).toHaveBeenCalledWith('data', expect.any(Function));
     });
 
     it('カスタムメッセージでEnterキーを待つ', async () => {
       const customMessage = 'Press any key...';
-      processStdinSpy.mockImplementation((event: string, callback: () => void) => {
+      processStdinOnSpy.mockImplementation((event: string, callback: (data: Buffer) => void) => {
         if (event === 'data') {
-          setTimeout(() => callback(), 0);
+          setTimeout(() => callback(Buffer.from('\n')), 0);
         }
         return process.stdin;
       });
+      processStdinRemoveListenerSpy.mockImplementation(() => process.stdin);
 
       const promise = Display.waitForEnter(customMessage);
       await promise;
@@ -169,20 +174,74 @@ describe('Display', () => {
       expect(processStdoutSpy).toHaveBeenCalledWith(expect.stringContaining(customMessage));
     });
 
-    it('データ受信時にresolveされる', async () => {
-      let resolveCallback: () => void;
-      processStdinSpy.mockImplementation((event: string, callback: () => void) => {
+    it('Enterキー（\\n）でresolveされる', async () => {
+      let resolveCallback: (data: Buffer) => void;
+      processStdinOnSpy.mockImplementation((event: string, callback: (data: Buffer) => void) => {
         if (event === 'data') {
-          resolveCallback = callback as () => void;
+          resolveCallback = callback as (data: Buffer) => void;
         }
         return process.stdin;
       });
+      processStdinRemoveListenerSpy.mockImplementation(() => process.stdin);
 
       const promise = Display.waitForEnter();
 
       // Simulate enter key press
-      setTimeout(() => resolveCallback(), 10);
+      setTimeout(() => resolveCallback(Buffer.from('\n')), 10);
 
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('Enterキー（\\r\\n）でresolveされる', async () => {
+      let resolveCallback: (data: Buffer) => void;
+      processStdinOnSpy.mockImplementation((event: string, callback: (data: Buffer) => void) => {
+        if (event === 'data') {
+          resolveCallback = callback as (data: Buffer) => void;
+        }
+        return process.stdin;
+      });
+      processStdinRemoveListenerSpy.mockImplementation(() => process.stdin);
+
+      const promise = Display.waitForEnter();
+
+      // Simulate enter key press (Windows style)
+      setTimeout(() => resolveCallback(Buffer.from('\r\n')), 10);
+
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('Enter以外のキーでは進まない', async () => {
+      let dataCallback: (data: Buffer) => void;
+
+      processStdinOnSpy.mockImplementation((event: string, callback: (data: Buffer) => void) => {
+        if (event === 'data') {
+          dataCallback = callback as (data: Buffer) => void;
+        }
+        return process.stdin;
+      });
+      processStdinRemoveListenerSpy.mockImplementation(() => process.stdin);
+
+      const promise = Display.waitForEnter();
+      let resolved = false;
+      promise.then(() => {
+        resolved = true;
+      });
+
+      // Enter以外のキーを押す
+      setTimeout(() => dataCallback(Buffer.from('a')), 10);
+      setTimeout(() => dataCallback(Buffer.from('1')), 20);
+      setTimeout(() => dataCallback(Buffer.from(' ')), 30);
+
+      // 少し待つ
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // まだresolveされていないことを確認
+      expect(resolved).toBe(false);
+
+      // Enterキーを押す
+      setTimeout(() => dataCallback(Buffer.from('\n')), 60);
+
+      // resolveされることを確認
       await expect(promise).resolves.toBeUndefined();
     });
   });

--- a/src/ui/Display.ts
+++ b/src/ui/Display.ts
@@ -54,9 +54,18 @@ export class Display {
   static async waitForEnter(message: string = 'Press Enter to continue...'): Promise<void> {
     return new Promise(resolve => {
       process.stdout.write(cyan(message));
-      process.stdin.once('data', () => {
-        resolve();
-      });
+
+      const onData = (data: Buffer) => {
+        const key = data.toString();
+        // Enterキー（\n または \r\n）の場合のみ処理
+        if (key === '\n' || key === '\r\n') {
+          process.stdin.removeListener('data', onData);
+          resolve();
+        }
+        // それ以外のキーは無視
+      };
+
+      process.stdin.on('data', onData);
     });
   }
 }


### PR DESCRIPTION
## 概要
Display.ts の `waitForEnter` メソッドがEnterキー以外のキーでも反応してしまう問題を修正しました。

## 修正内容
- `process.stdin.once('data', ...)` から `process.stdin.on('data', ...)` に変更
- 入力データを確認して改行文字（`\n` または `\r\n`）の場合のみ処理するように修正
- Enter以外のキーの場合はイベントリスナーを削除せずに継続して待機

## テストケース
- Enterキー（`\n`）で正常に動作することを確認
- Enterキー（`\r\n`）で正常に動作することを確認
- Enter以外のキーでは進まないことを確認

## 品質確認
- `npm run check` で全テストが通過
- フォーマットとリントチェックも通過

## 解決する問題
Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)