### PR TITLE
feat: change all game messages to Unix-style English (#8)

### DIFF
--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -30,6 +30,7 @@
 - **テストは日本語記述**: describe・testメソッドの説明文は日本語
 - **クラス名・変数名**: 英語（実装寄りの名前はそのまま）
 - **JSDocコメント**: 全てのクラスとメソッドにJSDoc形式のコメントを付与
+- **ユーザー向けメッセージ**: Unix風英語で記述（詳細は後述）
 
 ### 重要な指示
 package.jsonの`type`フィールドを変更してはならない
@@ -56,6 +57,33 @@ export class Player {
     // 実装
   }
 }
+```
+
+### Unix風メッセージガイドライン
+ユーザー向けのメッセージは以下の規約に従って記述します：
+
+**基本方針**
+- 小文字で始める（固有名詞除く）
+- 簡潔で技術的な表現を使用
+- 句読点は最小限に抑える
+- Unixコマンドスタイルの慣例に従う
+
+**メッセージ種別**
+- **成功メッセージ**: 動作完了を示す（例：`game started`, `directory changed`）
+- **エラーメッセージ**: 問題を簡潔に伝える（例：`no such file`, `permission denied`）
+- **情報メッセージ**: 状態や結果を示す（例：`current directory: /home`, `3 files found`）
+- **ヘルプメッセージ**: コマンドの使用方法（例：`usage: ls [options] [path]`）
+
+**具体例**
+```typescript
+// 良い例
+return this.success('new game started');
+return this.error('no such directory');
+return this.info('current path: /projects');
+
+// 避けるべき例
+return this.success('New game has been started successfully!');
+return this.error('The directory you specified does not exist.');
 ```
 
 ## 品質保証

--- a/src/commands/BaseCommand.ts
+++ b/src/commands/BaseCommand.ts
@@ -66,14 +66,14 @@ export abstract class BaseCommand {
       // 引数の検証
       const validation = this.validateArgs(args);
       if (!validation.valid) {
-        return this.error(validation.error || '引数が無効です');
+        return this.error(validation.error || 'invalid arguments');
       }
 
       // 実際のコマンド処理を実行
       return this.executeInternal(args, context);
     } catch (error) {
       return this.error(
-        `コマンド実行中にエラーが発生しました: ${error instanceof Error ? error.message : String(error)}`
+        `command execution failed: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }

--- a/src/commands/exploration/CdCommand.test.ts
+++ b/src/commands/exploration/CdCommand.test.ts
@@ -23,7 +23,7 @@ describe('CdCommand', () => {
   describe('基本プロパティ', () => {
     test('コマンド名とディスクリプション', () => {
       expect(command.name).toBe('cd');
-      expect(command.description).toBe('ディレクトリを移動します');
+      expect(command.description).toBe('change working directory');
     });
   });
 
@@ -35,7 +35,7 @@ describe('CdCommand', () => {
       const result = command.execute([], context);
 
       expect(result.success).toBe(true);
-      expect(result.message).toContain('移動しました');
+      expect(result.message).toContain('changed to');
       expect(fileSystem.pwd()).toBe('/projects');
     });
 
@@ -83,21 +83,21 @@ describe('CdCommand', () => {
       const result = command.execute(['nonexistent'], context);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('ディレクトリが見つかりません');
+      expect(result.message).toContain('no such directory');
     });
 
     test('ファイルへの移動はエラー', () => {
       const result = command.execute(['game-studio/README.md'], context);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('ディレクトリではありません');
+      expect(result.message).toContain('not a directory');
     });
 
     test('ルートより上への移動はエラー', () => {
       const result = command.execute(['..'], context);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('ルートディレクトリより上には移動できません');
+      expect(result.message).toContain('cannot change directory above root');
     });
   });
 
@@ -108,7 +108,7 @@ describe('CdCommand', () => {
       expect(help).toBeInstanceOf(Array);
       expect(help.length).toBeGreaterThan(0);
       expect(help[0]).toContain('cd');
-      expect(help.join('\n')).toContain('ディレクトリを移動します');
+      expect(help.join('\n')).toContain('change working directory');
     });
 
     test('使用例が含まれる', () => {

--- a/src/commands/exploration/CdCommand.ts
+++ b/src/commands/exploration/CdCommand.ts
@@ -1,40 +1,40 @@
 import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 
 /**
- * cdコマンド - ディレクトリの移動を行う
+ * cd command - change working directory
  */
 export class CdCommand extends BaseCommand {
   public name = 'cd';
-  public description = 'ディレクトリを移動します';
+  public description = 'change working directory';
 
   protected executeInternal(args: string[], context: CommandContext): CommandResult {
     const fileSystem = this.getFileSystem(context) as any;
     const targetPath = args[0];
 
-    // ディレクトリ移動を実行
+    // execute directory change
     const result = fileSystem.cd(targetPath);
 
     if (result.success) {
-      return this.success(`移動しました: ${fileSystem.pwd()}`);
+      return this.success(`changed to: ${fileSystem.pwd()}`);
     } else {
-      return this.error(result.error || 'ディレクトリの移動に失敗しました');
+      return this.error(result.error || 'change directory failed');
     }
   }
 
   public getHelp(): string[] {
     return [
-      'cd [path] - ディレクトリを移動します',
+      'cd [path] - change working directory',
       '',
-      '引数:',
-      '  path    移動先のパス（省略時はルートディレクトリ）',
+      'arguments:',
+      '  path    destination path (default: root directory)',
       '',
-      '例:',
-      '  cd              # ルートディレクトリに移動',
-      '  cd ~            # ルートディレクトリに移動',
-      '  cd ..           # 親ディレクトリに移動',
-      '  cd src          # srcディレクトリに移動',
-      '  cd /projects    # 絶対パスで移動',
-      '  cd ~/game       # ホームパスで移動',
+      'examples:',
+      '  cd              # change to root directory',
+      '  cd ~            # change to root directory',
+      '  cd ..           # change to parent directory',
+      '  cd src          # change to src directory',
+      '  cd /projects    # change using absolute path',
+      '  cd ~/game       # change using home path',
     ];
   }
 }

--- a/src/commands/exploration/CdCommand.ts
+++ b/src/commands/exploration/CdCommand.ts
@@ -1,7 +1,7 @@
 import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 
 /**
- * cd command - change working directory
+ * cd コマンド - ワーキングディレクトリを変更
  */
 export class CdCommand extends BaseCommand {
   public name = 'cd';
@@ -11,7 +11,7 @@ export class CdCommand extends BaseCommand {
     const fileSystem = this.getFileSystem(context) as any;
     const targetPath = args[0];
 
-    // execute directory change
+    // ディレクトリの変更を実行
     const result = fileSystem.cd(targetPath);
 
     if (result.success) {

--- a/src/commands/exploration/LsCommand.test.ts
+++ b/src/commands/exploration/LsCommand.test.ts
@@ -23,7 +23,7 @@ describe('LsCommand', () => {
   describe('基本プロパティ', () => {
     test('コマンド名とディスクリプション', () => {
       expect(command.name).toBe('ls');
-      expect(command.description).toBe('ファイル・ディレクトリ一覧を表示します');
+      expect(command.description).toBe('list directory contents');
     });
   });
 
@@ -32,7 +32,7 @@ describe('LsCommand', () => {
       const result = command.execute([], context);
 
       expect(result.success).toBe(true);
-      expect(result.message).toBe('ファイル一覧:');
+      expect(result.message).toBe('directory listing:');
       expect(result.output).toBeDefined();
       expect(result.output!.length).toBeGreaterThan(0);
     });
@@ -104,14 +104,14 @@ describe('LsCommand', () => {
       const result = command.execute(['nonexistent'], context);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('パスが見つかりません');
+      expect(result.message).toContain('no such path');
     });
 
     test('ファイルを指定した場合はエラー', () => {
       const result = command.execute(['game-studio/README.md'], context);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('ディレクトリではありません');
+      expect(result.message).toContain('not a directory');
     });
   });
 
@@ -159,7 +159,7 @@ describe('LsCommand', () => {
       expect(help).toBeInstanceOf(Array);
       expect(help.length).toBeGreaterThan(0);
       expect(help[0]).toContain('ls');
-      expect(help.join('\n')).toContain('ファイル・ディレクトリ一覧を表示します');
+      expect(help.join('\n')).toContain('list directory contents');
     });
 
     test('オプションの説明が含まれる', () => {

--- a/src/commands/exploration/LsCommand.ts
+++ b/src/commands/exploration/LsCommand.ts
@@ -2,51 +2,51 @@ import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 import { FileNode } from '../../world/FileNode';
 
 /**
- * lsコマンド - ファイル・ディレクトリの一覧を表示する
+ * ls command - list directory contents
  */
 export class LsCommand extends BaseCommand {
   public name = 'ls';
-  public description = 'ファイル・ディレクトリ一覧を表示します';
+  public description = 'list directory contents';
 
   protected executeInternal(args: string[], context: CommandContext): CommandResult {
     const fileSystem = this.getFileSystem(context) as any;
     const options = this.parseOptions(args);
     const targetPath = options.remaining[0];
 
-    // lsオプションを設定
+    // set ls options
     const listOptions = {
       showHidden: options.flags.includes('a') || options.flags.includes('all'),
       detailed: options.flags.includes('l') || options.flags.includes('long'),
       path: targetPath,
     };
 
-    // ファイル一覧を取得
+    // get file list
     const result = fileSystem.ls(listOptions);
 
     if (!result.success) {
-      return this.error(result.error || 'ファイル一覧の取得に失敗しました');
+      return this.error(result.error || 'failed to list directory');
     }
 
     if (!result.files || result.files.length === 0) {
-      return this.success('ディレクトリは空です', []);
+      return this.success('directory is empty', []);
     }
 
-    // 表示用の出力を生成
+    // generate output
     const output: string[] = [];
 
     if (listOptions.detailed) {
-      // 詳細表示
+      // detailed display
       output.push(...this.formatDetailedOutput(result.files));
     } else {
-      // 通常表示
+      // normal display
       output.push(...this.formatSimpleOutput(result.files));
     }
 
-    return this.success('ファイル一覧:', output);
+    return this.success('directory listing:', output);
   }
 
   /**
-   * 通常表示用のフォーマット
+   * format for normal display
    */
   private formatSimpleOutput(files: FileNode[]): string[] {
     const output: string[] = [];
@@ -56,7 +56,7 @@ export class LsCommand extends BaseCommand {
     for (const file of files) {
       const displayName = this.getDisplayName(file);
 
-      // 行の長さをチェック
+      // check line length
       if (currentLine.length + displayName.length + 2 > maxLineLength) {
         if (currentLine.length > 0) {
           output.push(currentLine.trim());
@@ -75,7 +75,7 @@ export class LsCommand extends BaseCommand {
   }
 
   /**
-   * 詳細表示用のフォーマット
+   * format for detailed display
    */
   private formatDetailedOutput(files: FileNode[]): string[] {
     const output: string[] = [];
@@ -94,7 +94,7 @@ export class LsCommand extends BaseCommand {
   }
 
   /**
-   * ファイルの表示名を取得（ディレクトリには/を付加）
+   * get file display name (add / to directories)
    */
   private getDisplayName(file: FileNode): string {
     let displayName = file.name;
@@ -107,10 +107,10 @@ export class LsCommand extends BaseCommand {
   }
 
   /**
-   * ファイルサイズを取得（簡単な実装）
+   * get file size (simple implementation)
    */
   private getFileSize(file: FileNode): string {
-    // ファイルタイプによって適当なサイズを返す
+    // return appropriate size based on file type
     switch (file.fileType) {
       case 'monster':
         return '1024';
@@ -127,22 +127,22 @@ export class LsCommand extends BaseCommand {
 
   public getHelp(): string[] {
     return [
-      'ls [options] [path] - ファイル・ディレクトリ一覧を表示します',
+      'ls [options] [path] - list directory contents',
       '',
-      'オプション:',
-      '  -a, --all      隠しファイルも表示します',
-      '  -l, --long     詳細情報を表示します',
+      'options:',
+      '  -a, --all      show hidden files',
+      '  -l, --long     show detailed information',
       '',
-      '引数:',
-      '  path          表示するディレクトリのパス（省略時は現在のディレクトリ）',
+      'arguments:',
+      '  path          directory path to list (default: current directory)',
       '',
-      '例:',
-      '  ls            # 現在のディレクトリの一覧表示',
-      '  ls -a         # 隠しファイルも含めて表示',
-      '  ls -l         # 詳細情報付きで表示',
-      '  ls -la        # 隠しファイルも含めて詳細表示',
-      '  ls src        # srcディレクトリの一覧表示',
-      '  ls -l ~/game  # ホームパスの詳細表示',
+      'examples:',
+      '  ls            # list current directory',
+      '  ls -a         # list including hidden files',
+      '  ls -l         # list with detailed information',
+      '  ls -la        # list all files with details',
+      '  ls src        # list src directory',
+      '  ls -l ~/game  # list home path with details',
     ];
   }
 }

--- a/src/commands/exploration/LsCommand.ts
+++ b/src/commands/exploration/LsCommand.ts
@@ -2,7 +2,7 @@ import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 import { FileNode } from '../../world/FileNode';
 
 /**
- * ls command - list directory contents
+ * ls コマンド - ディレクトリの内容を一覧表示
  */
 export class LsCommand extends BaseCommand {
   public name = 'ls';
@@ -13,14 +13,14 @@ export class LsCommand extends BaseCommand {
     const options = this.parseOptions(args);
     const targetPath = options.remaining[0];
 
-    // set ls options
+    // ls オプションを設定
     const listOptions = {
       showHidden: options.flags.includes('a') || options.flags.includes('all'),
       detailed: options.flags.includes('l') || options.flags.includes('long'),
       path: targetPath,
     };
 
-    // get file list
+    // ファイル一覧を取得
     const result = fileSystem.ls(listOptions);
 
     if (!result.success) {
@@ -31,14 +31,14 @@ export class LsCommand extends BaseCommand {
       return this.success('directory is empty', []);
     }
 
-    // generate output
+    // 出力を生成
     const output: string[] = [];
 
     if (listOptions.detailed) {
-      // detailed display
+      // 詳細表示
       output.push(...this.formatDetailedOutput(result.files));
     } else {
-      // normal display
+      // 通常表示
       output.push(...this.formatSimpleOutput(result.files));
     }
 
@@ -46,7 +46,7 @@ export class LsCommand extends BaseCommand {
   }
 
   /**
-   * format for normal display
+   * 通常表示のフォーマット
    */
   private formatSimpleOutput(files: FileNode[]): string[] {
     const output: string[] = [];
@@ -56,7 +56,7 @@ export class LsCommand extends BaseCommand {
     for (const file of files) {
       const displayName = this.getDisplayName(file);
 
-      // check line length
+      // 行の長さをチェック
       if (currentLine.length + displayName.length + 2 > maxLineLength) {
         if (currentLine.length > 0) {
           output.push(currentLine.trim());
@@ -75,7 +75,7 @@ export class LsCommand extends BaseCommand {
   }
 
   /**
-   * format for detailed display
+   * 詳細表示のフォーマット
    */
   private formatDetailedOutput(files: FileNode[]): string[] {
     const output: string[] = [];
@@ -94,7 +94,7 @@ export class LsCommand extends BaseCommand {
   }
 
   /**
-   * get file display name (add / to directories)
+   * ファイル表示名を取得（ディレクトリに / を追加）
    */
   private getDisplayName(file: FileNode): string {
     let displayName = file.name;
@@ -107,10 +107,10 @@ export class LsCommand extends BaseCommand {
   }
 
   /**
-   * get file size (simple implementation)
+   * ファイルサイズを取得（簡単な実装）
    */
   private getFileSize(file: FileNode): string {
-    // return appropriate size based on file type
+    // ファイルタイプに基づいて適切なサイズを返す
     switch (file.fileType) {
       case 'monster':
         return '1024';

--- a/src/commands/exploration/PwdCommand.test.ts
+++ b/src/commands/exploration/PwdCommand.test.ts
@@ -23,7 +23,7 @@ describe('PwdCommand', () => {
   describe('基本プロパティ', () => {
     test('コマンド名とディスクリプション', () => {
       expect(command.name).toBe('pwd');
-      expect(command.description).toBe('現在の作業ディレクトリのパスを表示します');
+      expect(command.description).toBe('print working directory');
     });
   });
 
@@ -93,14 +93,14 @@ describe('PwdCommand', () => {
       expect(help).toBeInstanceOf(Array);
       expect(help.length).toBeGreaterThan(0);
       expect(help[0]).toContain('pwd');
-      expect(help.join('\n')).toContain('現在の作業ディレクトリのパスを表示します');
+      expect(help.join('\n')).toContain('print working directory');
     });
 
     test('引数不要の説明が含まれる', () => {
       const help = command.getHelp();
       const helpText = help.join('\n');
 
-      expect(helpText).toContain('引数を取りません');
+      expect(helpText).toContain('takes no arguments');
     });
 
     test('使用例が含まれる', () => {

--- a/src/commands/exploration/PwdCommand.ts
+++ b/src/commands/exploration/PwdCommand.ts
@@ -1,7 +1,7 @@
 import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 
 /**
- * pwd command - print working directory
+ * pwd コマンド - ワーキングディレクトリを表示
  */
 export class PwdCommand extends BaseCommand {
   public name = 'pwd';

--- a/src/commands/exploration/PwdCommand.ts
+++ b/src/commands/exploration/PwdCommand.ts
@@ -1,11 +1,11 @@
 import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 
 /**
- * pwdコマンド - 現在の作業ディレクトリを表示する
+ * pwd command - print working directory
  */
 export class PwdCommand extends BaseCommand {
   public name = 'pwd';
-  public description = '現在の作業ディレクトリのパスを表示します';
+  public description = 'print working directory';
 
   protected executeInternal(_args: string[], context: CommandContext): CommandResult {
     const fileSystem = this.getFileSystem(context) as any;
@@ -15,15 +15,15 @@ export class PwdCommand extends BaseCommand {
 
   public getHelp(): string[] {
     return [
-      'pwd - 現在の作業ディレクトリのパスを表示します',
+      'pwd - print working directory',
       '',
-      'このコマンドは引数を取りません。',
-      '現在いるディレクトリの絶対パスを表示します。',
+      'this command takes no arguments.',
+      'displays the absolute path of the current directory.',
       '',
-      '例:',
-      '  pwd              # 現在のディレクトリパスを表示',
+      'examples:',
+      '  pwd              # display current directory path',
       '',
-      '出力例:',
+      'output example:',
       '  /projects/game-studio/src',
     ];
   }

--- a/src/commands/exploration/TreeCommand.test.ts
+++ b/src/commands/exploration/TreeCommand.test.ts
@@ -23,7 +23,7 @@ describe('TreeCommand', () => {
   describe('基本プロパティ', () => {
     test('コマンド名とディスクリプション', () => {
       expect(command.name).toBe('tree');
-      expect(command.description).toBe('ディレクトリ構造をツリー形式で表示します');
+      expect(command.description).toBe('display directory tree structure');
     });
   });
 
@@ -32,7 +32,7 @@ describe('TreeCommand', () => {
       const result = command.execute([], context);
 
       expect(result.success).toBe(true);
-      expect(result.message).toBe('ディレクトリツリー:');
+      expect(result.message).toBe('directory tree:');
       expect(result.output).toBeDefined();
       expect(result.output!.length).toBeGreaterThan(0);
 
@@ -182,7 +182,7 @@ describe('TreeCommand', () => {
       expect(help).toBeInstanceOf(Array);
       expect(help.length).toBeGreaterThan(0);
       expect(help[0]).toContain('tree');
-      expect(help.join('\n')).toContain('ディレクトリ構造をツリー形式で表示します');
+      expect(help.join('\n')).toContain('display directory tree structure');
     });
 
     test('オプションの説明が含まれる', () => {

--- a/src/commands/exploration/TreeCommand.ts
+++ b/src/commands/exploration/TreeCommand.ts
@@ -2,40 +2,40 @@ import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 import { TreeNode } from '../../world/FileSystem';
 
 /**
- * treeコマンド - ディレクトリ構造をツリー形式で表示する
+ * tree command - display directory tree structure
  */
 export class TreeCommand extends BaseCommand {
   public name = 'tree';
-  public description = 'ディレクトリ構造をツリー形式で表示します';
+  public description = 'display directory tree structure';
 
   protected executeInternal(args: string[], context: CommandContext): CommandResult {
     const fileSystem = this.getFileSystem(context) as any;
     const options = this.parseOptions(args);
 
-    // treeオプションを設定
+    // set tree options
     const treeOptions = {
       showHidden: options.flags.includes('a') || options.flags.includes('all'),
       maxDepth: this.getDepthOption(options),
     };
 
-    // ツリーデータを取得
+    // get tree data
     const treeData = fileSystem.tree(treeOptions);
 
-    // ツリー表示用の出力を生成
+    // generate tree output
     const output = this.formatTreeOutput(treeData, treeOptions.showHidden);
 
-    return this.success('ディレクトリツリー:', output);
+    return this.success('directory tree:', output);
   }
 
   /**
-   * 深度オプションを取得する
+   * get depth option
    */
   private getDepthOption(options: {
     flags: string[];
     values: Record<string, string>;
     remaining: string[];
   }): number | undefined {
-    // --depth または -d オプションから深度を取得
+    // get depth from --depth or -d option
     const depthValue = options.values['depth'] || options.values['d'];
     if (depthValue) {
       const depth = parseInt(depthValue, 10);
@@ -43,11 +43,11 @@ export class TreeCommand extends BaseCommand {
         return depth;
       }
     }
-    return undefined; // 制限なし
+    return undefined; // no limit
   }
 
   /**
-   * ツリー形式の出力をフォーマットする
+   * format tree output
    */
   private formatTreeOutput(treeNode: TreeNode, showHidden: boolean): string[] {
     const output: string[] = [];
@@ -56,7 +56,7 @@ export class TreeCommand extends BaseCommand {
   }
 
   /**
-   * 単一のツリーノードをフォーマットする
+   * format single tree node
    */
   private formatTreeNode(
     node: TreeNode,
@@ -64,16 +64,16 @@ export class TreeCommand extends BaseCommand {
     isLast: boolean,
     context: { output: string[]; showHidden: boolean }
   ): void {
-    // ノード名の表示
+    // display node name
     const connector = isLast ? '└── ' : '├── ';
     const displayName = this.getNodeDisplayName(node);
     context.output.push(prefix + connector + displayName);
 
-    // 子ノードの処理
+    // process child nodes
     if (node.children && node.children.length > 0) {
       let visibleChildren = node.children;
 
-      // 隠しファイルのフィルタリング
+      // filter hidden files
       if (!context.showHidden) {
         visibleChildren = node.children.filter(child => !child.name.startsWith('.'));
       }
@@ -88,17 +88,17 @@ export class TreeCommand extends BaseCommand {
   }
 
   /**
-   * ノードの表示名を取得する
+   * get node display name
    */
   private getNodeDisplayName(node: TreeNode): string {
     let displayName = node.name;
 
-    // ディレクトリには/を付加
+    // add / to directories
     if (node.nodeType === 'directory') {
       displayName += '/';
     }
 
-    // ファイルタイプに応じてアイコンを追加
+    // add icon based on file type
     const icon = this.getFileTypeIcon(node.fileType);
     if (icon) {
       displayName += ` ${icon}`;
@@ -108,46 +108,46 @@ export class TreeCommand extends BaseCommand {
   }
 
   /**
-   * ファイルタイプに応じたアイコンを取得する
+   * get icon based on file type
    */
   private getFileTypeIcon(fileType?: string): string {
     switch (fileType) {
       case 'monster':
-        return '⚔️'; // モンスターファイル
+        return '⚔️'; // monster file
       case 'treasure':
-        return '💰'; // 宝箱ファイル
+        return '💰'; // treasure file
       case 'save_point':
-        return '💾'; // セーブポイント
+        return '💾'; // save point
       case 'event':
-        return '🎭'; // イベントファイル
+        return '🎭'; // event file
       case 'empty':
-        return '📄'; // 空ファイル
+        return '📄'; // empty file
       default:
-        return ''; // ディレクトリや不明なタイプ
+        return ''; // directory or unknown type
     }
   }
 
   public getHelp(): string[] {
     return [
-      'tree [options] - ディレクトリ構造をツリー形式で表示します',
+      'tree [options] - display directory tree structure',
       '',
-      'オプション:',
-      '  -a, --all         隠しファイルも表示します',
-      '  -d, --depth N     表示する最大深度を指定します',
+      'options:',
+      '  -a, --all         show hidden files',
+      '  -d, --depth N     specify maximum depth to display',
       '',
-      '例:',
-      '  tree              # 現在のディレクトリのツリー表示',
-      '  tree -a           # 隠しファイルも含めてツリー表示',
-      '  tree -d 2         # 深度2までのツリー表示',
-      '  tree --depth 3    # 深度3までのツリー表示',
-      '  tree -a -d 2      # 隠しファイルも含めて深度2まで表示',
+      'examples:',
+      '  tree              # display tree of current directory',
+      '  tree -a           # display tree including hidden files',
+      '  tree -d 2         # display tree up to depth 2',
+      '  tree --depth 3    # display tree up to depth 3',
+      '  tree -a -d 2      # show hidden files up to depth 2',
       '',
-      'ファイルタイプアイコン:',
-      '  ⚔️  モンスターファイル (.js, .ts, .py等)',
-      '  💰 宝箱ファイル (.json, .yaml等)',
-      '  💾 セーブポイント (.md)',
-      '  🎭 イベントファイル (.exe, .bin等)',
-      '  📄 空ファイル (その他)',
+      'file type icons:',
+      '  ⚔️  monster files (.js, .ts, .py etc)',
+      '  💰 treasure files (.json, .yaml etc)',
+      '  💾 save points (.md)',
+      '  🎭 event files (.exe, .bin etc)',
+      '  📄 empty files (others)',
     ];
   }
 }

--- a/src/commands/exploration/TreeCommand.ts
+++ b/src/commands/exploration/TreeCommand.ts
@@ -2,7 +2,7 @@ import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 import { TreeNode } from '../../world/FileSystem';
 
 /**
- * tree command - display directory tree structure
+ * tree コマンド - ディレクトリツリー構造を表示
  */
 export class TreeCommand extends BaseCommand {
   public name = 'tree';
@@ -12,30 +12,30 @@ export class TreeCommand extends BaseCommand {
     const fileSystem = this.getFileSystem(context) as any;
     const options = this.parseOptions(args);
 
-    // set tree options
+    // ツリーオプションを設定
     const treeOptions = {
       showHidden: options.flags.includes('a') || options.flags.includes('all'),
       maxDepth: this.getDepthOption(options),
     };
 
-    // get tree data
+    // ツリーデータを取得
     const treeData = fileSystem.tree(treeOptions);
 
-    // generate tree output
+    // ツリー出力を生成
     const output = this.formatTreeOutput(treeData, treeOptions.showHidden);
 
     return this.success('directory tree:', output);
   }
 
   /**
-   * get depth option
+   * 深度オプションを取得
    */
   private getDepthOption(options: {
     flags: string[];
     values: Record<string, string>;
     remaining: string[];
   }): number | undefined {
-    // get depth from --depth or -d option
+    // --depth または -d オプションから深度を取得
     const depthValue = options.values['depth'] || options.values['d'];
     if (depthValue) {
       const depth = parseInt(depthValue, 10);
@@ -43,11 +43,11 @@ export class TreeCommand extends BaseCommand {
         return depth;
       }
     }
-    return undefined; // no limit
+    return undefined; // 制限なし
   }
 
   /**
-   * format tree output
+   * ツリー出力をフォーマット
    */
   private formatTreeOutput(treeNode: TreeNode, showHidden: boolean): string[] {
     const output: string[] = [];
@@ -56,7 +56,7 @@ export class TreeCommand extends BaseCommand {
   }
 
   /**
-   * format single tree node
+   * 単一のツリーノードをフォーマット
    */
   private formatTreeNode(
     node: TreeNode,
@@ -64,16 +64,16 @@ export class TreeCommand extends BaseCommand {
     isLast: boolean,
     context: { output: string[]; showHidden: boolean }
   ): void {
-    // display node name
+    // ノード名を表示
     const connector = isLast ? '└── ' : '├── ';
     const displayName = this.getNodeDisplayName(node);
     context.output.push(prefix + connector + displayName);
 
-    // process child nodes
+    // 子ノードを処理
     if (node.children && node.children.length > 0) {
       let visibleChildren = node.children;
 
-      // filter hidden files
+      // 隠しファイルをフィルタ
       if (!context.showHidden) {
         visibleChildren = node.children.filter(child => !child.name.startsWith('.'));
       }
@@ -88,17 +88,17 @@ export class TreeCommand extends BaseCommand {
   }
 
   /**
-   * get node display name
+   * ノード表示名を取得
    */
   private getNodeDisplayName(node: TreeNode): string {
     let displayName = node.name;
 
-    // add / to directories
+    // ディレクトリに / を追加
     if (node.nodeType === 'directory') {
       displayName += '/';
     }
 
-    // add icon based on file type
+    // ファイルタイプに基づいてアイコンを追加
     const icon = this.getFileTypeIcon(node.fileType);
     if (icon) {
       displayName += ` ${icon}`;
@@ -108,22 +108,22 @@ export class TreeCommand extends BaseCommand {
   }
 
   /**
-   * get icon based on file type
+   * ファイルタイプに基づいてアイコンを取得
    */
   private getFileTypeIcon(fileType?: string): string {
     switch (fileType) {
       case 'monster':
-        return '⚔️'; // monster file
+        return '⚔️'; // モンスターファイル
       case 'treasure':
-        return '💰'; // treasure file
+        return '💰'; // 宝物ファイル
       case 'save_point':
-        return '💾'; // save point
+        return '💾'; // セーブポイント
       case 'event':
-        return '🎭'; // event file
+        return '🎭'; // イベントファイル
       case 'empty':
-        return '📄'; // empty file
+        return '📄'; // 空のファイル
       default:
-        return ''; // directory or unknown type
+        return ''; // ディレクトリまたは不明なタイプ
     }
   }
 

--- a/src/commands/title/ExitCommand.test.ts
+++ b/src/commands/title/ExitCommand.test.ts
@@ -22,7 +22,7 @@ describe('ExitCommand', () => {
     });
 
     test('説明文が設定されている', () => {
-      expect(command.description).toBe('ゲームを終了する');
+      expect(command.description).toBe('exit game');
     });
   });
 
@@ -31,15 +31,15 @@ describe('ExitCommand', () => {
       const result = command.execute([], context);
 
       expect(result.success).toBe(true);
-      expect(result.message).toContain('ゲームを終了します');
-      expect(result.message).toContain('ありがとうございました');
+      expect(result.message).toContain('exiting game');
+      expect(result.message).toContain('thanks for playing');
     });
 
     test('引数があっても正常に動作する', () => {
       const result = command.execute(['extra', 'args'], context);
 
       expect(result.success).toBe(true);
-      expect(result.message).toContain('ゲームを終了します');
+      expect(result.message).toContain('exiting game');
     });
   });
 

--- a/src/commands/title/ExitCommand.ts
+++ b/src/commands/title/ExitCommand.ts
@@ -1,29 +1,29 @@
 import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 
 /**
- * exitコマンド - ゲームを終了する
+ * exit command - exit game
  */
 export class ExitCommand extends BaseCommand {
   public name = 'exit';
-  public description = 'ゲームを終了する';
+  public description = 'exit game';
 
   protected executeInternal(_args: string[], _context: CommandContext): CommandResult {
     return this.success(
-      'ゲームを終了します。TypEngQuestをプレイしていただき、ありがとうございました！',
+      'exiting game. thanks for playing TypEngQuest!',
       undefined
     );
   }
 
   public getHelp(): string[] {
     return [
-      'exit - ゲームを終了します',
+      'exit - exit game',
       '',
-      '使用法:',
+      'usage:',
       '  exit',
       '',
-      '説明:',
-      '  ゲームを終了してタイトル画面を閉じます。',
-      '  保存されていない進行状況は失われます。',
+      'description:',
+      '  exit game and close title screen.',
+      '  unsaved progress will be lost.',
     ];
   }
 }

--- a/src/commands/title/ExitCommand.ts
+++ b/src/commands/title/ExitCommand.ts
@@ -1,7 +1,7 @@
 import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 
 /**
- * exit command - exit game
+ * exit コマンド - ゲームを終了
  */
 export class ExitCommand extends BaseCommand {
   public name = 'exit';

--- a/src/commands/title/LoadCommand.test.ts
+++ b/src/commands/title/LoadCommand.test.ts
@@ -22,7 +22,7 @@ describe('LoadCommand', () => {
     });
 
     test('説明文が設定されている', () => {
-      expect(command.description).toBe('セーブデータをロードする');
+      expect(command.description).toBe('load saved game');
     });
   });
 
@@ -31,21 +31,21 @@ describe('LoadCommand', () => {
       const result = command.execute([], context);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('セーブファイルが見つかりません');
+      expect(result.message).toContain('no save file found');
     });
 
     test('スロット番号指定時にエラーメッセージを返す', () => {
       const result = command.execute(['1'], context);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('セーブスロット1が見つかりません');
+      expect(result.message).toContain('save slot 1 not found');
     });
 
     test('複数の引数でも最初の引数をスロット番号として使用', () => {
       const result = command.execute(['2', 'extra'], context);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('セーブスロット2が見つかりません');
+      expect(result.message).toContain('save slot 2 not found');
     });
   });
 

--- a/src/commands/title/LoadCommand.ts
+++ b/src/commands/title/LoadCommand.ts
@@ -1,33 +1,33 @@
 import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 
 /**
- * loadコマンド - セーブデータをロードする
+ * load command - load saved game
  */
 export class LoadCommand extends BaseCommand {
   public name = 'load';
-  public description = 'セーブデータをロードする';
+  public description = 'load saved game';
 
   protected executeInternal(args: string[], _context: CommandContext): CommandResult {
-    // セーブファイルの確認（現在は未実装のため固定メッセージ）
+    // check save file (not implemented yet, fixed message)
     if (args.length > 0) {
       const saveSlot = args[0];
-      return this.error(`セーブスロット${saveSlot}が見つかりません。`);
+      return this.error(`save slot ${saveSlot} not found`);
     }
 
-    return this.error('セーブファイルが見つかりません。startコマンドで新しいゲームを始めてください。');
+    return this.error('no save file found. use start command to begin new game');
   }
 
   public getHelp(): string[] {
     return [
-      'load [スロット番号] - セーブデータをロードします',
+      'load [slot] - load saved game',
       '',
-      '使用法:',
+      'usage:',
       '  load',
       '  load 1',
       '',
-      '説明:',
-      '  指定したスロットのセーブデータをロードします。',
-      '  スロット番号を省略した場合、利用可能なセーブファイル一覧を表示します。',
+      'description:',
+      '  load game data from specified slot.',
+      '  if no slot specified, show available save files.',
     ];
   }
 }

--- a/src/commands/title/LoadCommand.ts
+++ b/src/commands/title/LoadCommand.ts
@@ -1,14 +1,14 @@
 import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 
 /**
- * load command - load saved game
+ * load コマンド - セーブされたゲームを読み込み
  */
 export class LoadCommand extends BaseCommand {
   public name = 'load';
   public description = 'load saved game';
 
   protected executeInternal(args: string[], _context: CommandContext): CommandResult {
-    // check save file (not implemented yet, fixed message)
+    // セーブファイルをチェック（未実装、固定メッセージ）
     if (args.length > 0) {
       const saveSlot = args[0];
       return this.error(`save slot ${saveSlot} not found`);

--- a/src/commands/title/StartCommand.test.ts
+++ b/src/commands/title/StartCommand.test.ts
@@ -22,7 +22,7 @@ describe('StartCommand', () => {
     });
 
     test('説明文が設定されている', () => {
-      expect(command.description).toBe('新しいゲームを開始する');
+      expect(command.description).toBe('start new game');
     });
   });
 
@@ -31,7 +31,7 @@ describe('StartCommand', () => {
       const result = command.execute([], context);
 
       expect(result.success).toBe(true);
-      expect(result.message).toBe('新しいゲームを開始しました！');
+      expect(result.message).toBe('new game started!');
       expect(result.nextPhase).toBe('exploration');
       expect(result.data).toEqual({ newGame: true });
     });

--- a/src/commands/title/StartCommand.ts
+++ b/src/commands/title/StartCommand.ts
@@ -1,16 +1,16 @@
 import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 
 /**
- * startコマンド - 新しいゲームを開始する
+ * start command - start new game
  */
 export class StartCommand extends BaseCommand {
   public name = 'start';
-  public description = '新しいゲームを開始する';
+  public description = 'start new game';
 
   protected executeInternal(_args: string[], _context: CommandContext): CommandResult {
-    // 新しいゲーム開始処理
+    // start new game
     return this.successWithPhase(
-      '新しいゲームを開始しました！',
+      'new game started!',
       'exploration',
       { newGame: true }
     );
@@ -18,14 +18,14 @@ export class StartCommand extends BaseCommand {
 
   public getHelp(): string[] {
     return [
-      'start - 新しいゲームを開始します',
+      'start - start new game',
       '',
-      '使用法:',
+      'usage:',
       '  start',
       '',
-      '説明:',
-      '  新しい冒険を始めます。',
-      '  現在の進行状況は失われます。',
+      'description:',
+      '  begin a new adventure.',
+      '  current progress will be lost.',
     ];
   }
 }

--- a/src/commands/title/StartCommand.ts
+++ b/src/commands/title/StartCommand.ts
@@ -1,14 +1,14 @@
 import { BaseCommand, CommandResult, CommandContext } from '../BaseCommand';
 
 /**
- * start command - start new game
+ * start コマンド - 新しいゲームを開始
  */
 export class StartCommand extends BaseCommand {
   public name = 'start';
   public description = 'start new game';
 
   protected executeInternal(_args: string[], _context: CommandContext): CommandResult {
-    // start new game
+    // 新しいゲームを開始
     return this.successWithPhase(
       'new game started!',
       'exploration',

--- a/src/phases/ExplorationPhase.test.ts
+++ b/src/phases/ExplorationPhase.test.ts
@@ -45,7 +45,9 @@ describe('ExplorationPhase', () => {
     test('ファイルシステムが初期化される', () => {
       // enter()を呼んで現在地が表示されることを確認
       phase.enter();
-      expect(mockPrintSuccess).toHaveBeenCalledWith(expect.stringContaining('現在地: /projects'));
+      expect(mockPrintSuccess).toHaveBeenCalledWith(
+        expect.stringContaining('current location: /projects')
+      );
     });
   });
 
@@ -57,18 +59,18 @@ describe('ExplorationPhase', () => {
 
     test('ヘッダーが表示される', () => {
       phase.enter();
-      expect(mockPrintHeader).toHaveBeenCalledWith('マップ探索モード');
+      expect(mockPrintHeader).toHaveBeenCalledWith('exploration mode');
     });
 
     test('説明文が表示される', () => {
       phase.enter();
-      expect(mockPrintInfo).toHaveBeenCalledWith('仮想ファイルシステムを探索できます。');
-      expect(mockPrintInfo).toHaveBeenCalledWith('helpコマンドで利用可能なコマンドを表示します。');
+      expect(mockPrintInfo).toHaveBeenCalledWith('explore the virtual filesystem.');
+      expect(mockPrintInfo).toHaveBeenCalledWith('type "help" to see available commands.');
     });
 
     test('現在地が表示される', () => {
       phase.enter();
-      expect(mockPrintSuccess).toHaveBeenCalledWith('現在地: /projects');
+      expect(mockPrintSuccess).toHaveBeenCalledWith('current location: /projects');
     });
 
     test('プロンプトが表示される', () => {
@@ -88,7 +90,7 @@ describe('ExplorationPhase', () => {
         const result = (phase as any).processCommand('cd game-studio');
 
         expect(result.type).toBe(PhaseTypes.CONTINUE);
-        expect(mockPrintSuccess).toHaveBeenCalledWith(expect.stringContaining('移動しました'));
+        expect(mockPrintSuccess).toHaveBeenCalledWith(expect.stringContaining('changed to'));
       });
 
       test('lsコマンドが動作する', () => {
@@ -116,9 +118,7 @@ describe('ExplorationPhase', () => {
         const result = (phase as any).processCommand('cd nonexistent');
 
         expect(result.type).toBe(PhaseTypes.CONTINUE);
-        expect(mockPrintError).toHaveBeenCalledWith(
-          expect.stringContaining('ディレクトリが見つかりません')
-        );
+        expect(mockPrintError).toHaveBeenCalledWith(expect.stringContaining('no such directory'));
       });
     });
 
@@ -127,7 +127,7 @@ describe('ExplorationPhase', () => {
         const result = (phase as any).processCommand('help');
 
         expect(result.type).toBe(PhaseTypes.CONTINUE);
-        expect(mockPrintHeader).toHaveBeenCalledWith('利用可能なコマンド');
+        expect(mockPrintHeader).toHaveBeenCalledWith('available commands');
         expect(mockPrintCommand).toHaveBeenCalled();
       });
 
@@ -143,7 +143,7 @@ describe('ExplorationPhase', () => {
         const result = (phase as any).processCommand('exit');
 
         expect(result.type).toBe(PhaseTypes.TITLE);
-        expect(mockPrintInfo).toHaveBeenCalledWith('タイトル画面に戻ります...');
+        expect(mockPrintInfo).toHaveBeenCalledWith('returning to title...');
       });
 
       test('quitコマンドでタイトルに戻る', () => {
@@ -163,8 +163,8 @@ describe('ExplorationPhase', () => {
       const result = (phase as any).processCommand('unknown');
 
       expect(result.type).toBe(PhaseTypes.CONTINUE);
-      expect(mockPrintError).toHaveBeenCalledWith('不明なコマンド: unknown');
-      expect(mockPrintInfo).toHaveBeenCalledWith('helpで利用可能なコマンドを確認してください。');
+      expect(mockPrintError).toHaveBeenCalledWith('command not found: unknown');
+      expect(mockPrintInfo).toHaveBeenCalledWith('type "help" to see available commands.');
     });
 
     test('空のコマンドで継続', () => {
@@ -215,7 +215,7 @@ describe('ExplorationPhase', () => {
 
       (phase as any).processCommand('help');
 
-      expect(mockPrintInfo).toHaveBeenCalledWith('ナビゲーション:');
+      expect(mockPrintInfo).toHaveBeenCalledWith('navigation:');
       expect(mockPrintCommand).toHaveBeenCalledWith('cd', expect.any(String));
       expect(mockPrintCommand).toHaveBeenCalledWith('ls', expect.any(String));
       expect(mockPrintCommand).toHaveBeenCalledWith('pwd', expect.any(String));
@@ -228,10 +228,10 @@ describe('ExplorationPhase', () => {
 
       (phase as any).processCommand('help');
 
-      expect(mockPrintInfo).toHaveBeenCalledWith('システム:');
-      expect(mockPrintCommand).toHaveBeenCalledWith('help', 'このヘルプを表示');
-      expect(mockPrintCommand).toHaveBeenCalledWith('clear', '画面をクリア');
-      expect(mockPrintCommand).toHaveBeenCalledWith('exit', 'タイトル画面に戻る');
+      expect(mockPrintInfo).toHaveBeenCalledWith('system:');
+      expect(mockPrintCommand).toHaveBeenCalledWith('help', 'show this help');
+      expect(mockPrintCommand).toHaveBeenCalledWith('clear', 'clear screen');
+      expect(mockPrintCommand).toHaveBeenCalledWith('exit', 'return to title');
     });
 
     test('詳細ヘルプの案内が表示される', () => {
@@ -240,9 +240,7 @@ describe('ExplorationPhase', () => {
 
       (phase as any).processCommand('help');
 
-      expect(mockPrintInfo).toHaveBeenCalledWith(
-        '各コマンドの詳細は「コマンド名 --help」で確認できます。'
-      );
+      expect(mockPrintInfo).toHaveBeenCalledWith('use "command --help" for detailed information.');
     });
   });
 

--- a/src/phases/ExplorationPhase.ts
+++ b/src/phases/ExplorationPhase.ts
@@ -48,14 +48,14 @@ export class ExplorationPhase extends Phase {
 
   public enter(): void {
     Display.clear();
-    Display.printHeader('マップ探索モード');
+    Display.printHeader('exploration mode');
     Display.newLine();
-    Display.printInfo('仮想ファイルシステムを探索できます。');
-    Display.printInfo('helpコマンドで利用可能なコマンドを表示します。');
+    Display.printInfo('explore the virtual filesystem.');
+    Display.printInfo('type "help" to see available commands.');
     Display.newLine();
 
     // 現在地を表示
-    Display.printSuccess(`現在地: ${this.fileSystem.pwd()}`);
+    Display.printSuccess(`current location: ${this.fileSystem.pwd()}`);
     Display.newLine();
 
     // プロンプトを表示
@@ -99,7 +99,7 @@ export class ExplorationPhase extends Phase {
     // 無効なコマンドの場合は失敗を返す
     return {
       success: false,
-      message: `不明なコマンド: ${command}`,
+      message: `command not found: ${command}`,
     };
   }
 
@@ -148,10 +148,10 @@ export class ExplorationPhase extends Phase {
         result.output.forEach(line => Display.printLine(line));
       } else if (result.message) {
         // メッセージのみの場合
-        Display.printSuccess(result.message || '操作が完了しました');
+        Display.printSuccess(result.message || 'operation completed');
       }
     } else {
-      Display.printError(result.message || 'エラーが発生しました');
+      Display.printError(result.message || 'operation failed');
     }
 
     Display.newLine();
@@ -173,7 +173,7 @@ export class ExplorationPhase extends Phase {
       case 'exit':
       case 'quit':
       case 'q':
-        Display.printInfo('タイトル画面に戻ります...');
+        Display.printInfo('returning to title...');
         return { type: PhaseTypes.TITLE };
 
       case 'clear':
@@ -183,8 +183,8 @@ export class ExplorationPhase extends Phase {
         return { type: PhaseTypes.CONTINUE };
 
       default:
-        Display.printError(`不明なコマンド: ${command}`);
-        Display.printInfo('helpで利用可能なコマンドを確認してください。');
+        Display.printError(`command not found: ${command}`);
+        Display.printInfo('type "help" to see available commands.');
         Display.newLine();
         this.showPrompt();
         return { type: PhaseTypes.CONTINUE };
@@ -196,11 +196,11 @@ export class ExplorationPhase extends Phase {
    */
   private showHelp(): void {
     Display.newLine();
-    Display.printHeader('利用可能なコマンド');
+    Display.printHeader('available commands');
     Display.printLine('------------------');
 
     // ナビゲーションコマンド
-    Display.printInfo('ナビゲーション:');
+    Display.printInfo('navigation:');
     this.navigationCommands.forEach(command => {
       Display.printCommand(command.name, command.description);
     });
@@ -208,13 +208,13 @@ export class ExplorationPhase extends Phase {
     Display.newLine();
 
     // システムコマンド
-    Display.printInfo('システム:');
-    Display.printCommand('help', 'このヘルプを表示');
-    Display.printCommand('clear', '画面をクリア');
-    Display.printCommand('exit', 'タイトル画面に戻る');
+    Display.printInfo('system:');
+    Display.printCommand('help', 'show this help');
+    Display.printCommand('clear', 'clear screen');
+    Display.printCommand('exit', 'return to title');
 
     Display.newLine();
-    Display.printInfo('各コマンドの詳細は「コマンド名 --help」で確認できます。');
+    Display.printInfo('use "command --help" for detailed information.');
     Display.newLine();
     this.showPrompt();
   }

--- a/src/tests/integration/exploration-phase.integration.test.ts
+++ b/src/tests/integration/exploration-phase.integration.test.ts
@@ -181,7 +181,7 @@ describe('Explorationフェーズの統合テスト', () => {
       const result = await explorationPhase.processInput('invalid_navigation_command');
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('不明なコマンド');
+      expect(result.message).toContain('command not found');
     });
 
     test('存在しないディレクトリへのcd操作でエラーが適切に処理されること', async () => {

--- a/src/tests/integration/phase-transitions.integration.test.ts
+++ b/src/tests/integration/phase-transitions.integration.test.ts
@@ -62,9 +62,9 @@ describe('フェーズ移行の統合テスト', () => {
       // フェーズ遷移に関連する出力があることを確認
       const output = gameHelper.getCapturedOutput();
       const hasTransitionOutput = output.some(line =>
-        line.includes('マップ探索') ||
-        line.includes('仮想ファイルシステム') ||
-        line.includes('現在地')
+        line.includes('exploration mode') ||
+        line.includes('virtual filesystem') ||
+        line.includes('current location')
       );
 
       expect(hasTransitionOutput).toBe(true);

--- a/src/world/FileSystem.test.ts
+++ b/src/world/FileSystem.test.ts
@@ -91,7 +91,7 @@ describe('FileSystem', () => {
     test('存在しないディレクトリへの移動はエラー', () => {
       const result = fileSystem.cd('nonexistent');
       expect(result.success).toBe(false);
-      expect(result.error).toContain('ディレクトリが見つかりません');
+      expect(result.error).toContain('no such directory');
       expect(fileSystem.pwd()).toBe('/projects'); // 移動していない
     });
 
@@ -99,13 +99,13 @@ describe('FileSystem', () => {
       fileSystem.cd('game-studio/src');
       const result = fileSystem.cd('main.js');
       expect(result.success).toBe(false);
-      expect(result.error).toContain('ディレクトリではありません');
+      expect(result.error).toContain('not a directory');
     });
 
     test('ルートより上への移動はエラー', () => {
       const result = fileSystem.cd('..');
       expect(result.success).toBe(false);
-      expect(result.error).toContain('ルートディレクトリより上には移動できません');
+      expect(result.error).toContain('cannot change directory above root');
     });
 
     test('ホームディレクトリ（~）への移動', () => {
@@ -204,7 +204,7 @@ describe('FileSystem', () => {
     test('存在しないパスの一覧取得はエラー', () => {
       const result = fileSystem.ls({ path: 'nonexistent' });
       expect(result.success).toBe(false);
-      expect(result.error).toContain('パスが見つかりません');
+      expect(result.error).toContain('no such path');
     });
   });
 

--- a/src/world/FileSystem.ts
+++ b/src/world/FileSystem.ts
@@ -58,7 +58,7 @@ export class FileSystem {
    */
   constructor(root: FileNode) {
     if (!root.isDirectory()) {
-      throw new Error('ルートノードはディレクトリである必要があります');
+      throw new Error('root node must be a directory');
     }
 
     this.root = root;
@@ -90,7 +90,7 @@ export class FileSystem {
       if (this.currentNode === this.root) {
         return {
           success: false,
-          error: 'ルートディレクトリより上には移動できません',
+          error: 'cannot change directory above root',
         };
       }
       this.currentNode = this.currentNode.parent!;
@@ -102,14 +102,14 @@ export class FileSystem {
     if (!targetNode) {
       return {
         success: false,
-        error: `ディレクトリが見つかりません: ${path}`,
+        error: `no such directory: ${path}`,
       };
     }
 
     if (!targetNode.isDirectory()) {
       return {
         success: false,
-        error: `${path} はディレクトリではありません`,
+        error: `${path}: not a directory`,
       };
     }
 
@@ -131,14 +131,14 @@ export class FileSystem {
       if (!node) {
         return {
           success: false,
-          error: `パスが見つかりません: ${options.path}`,
+          error: `no such path: ${options.path}`,
         };
       }
 
       if (!node.isDirectory()) {
         return {
           success: false,
-          error: `${options.path} はディレクトリではありません`,
+          error: `${options.path}: not a directory`,
         };
       }
 


### PR DESCRIPTION
close #8 

## Summary
- Changed all user-facing game messages from Japanese to Unix-style English
- Added Unix-style message guidelines to development documentation
- Updated all corresponding test cases to match new message format

## Changes Made
- **BaseCommand**: Updated error messages (`invalid arguments`, `command execution failed`)
- **FileSystem**: Updated all operation messages (`no such directory`, `not a directory`, etc.)
- **ExplorationPhase**: Updated system messages (`exploration mode`, `command not found`)
- **All Commands**: Updated descriptions and help text to Unix-style English
- **Documentation**: Added comprehensive Unix-style message guidelines
- **Tests**: Updated all test assertions to match new message format

## Message Style Guidelines
- Lowercase start (except proper nouns)
- Concise and technical expressions
- Minimal punctuation
- Following Unix command conventions

## Test Coverage
- All 397 tests passing
- Quality checks (lint, format, typecheck) passing
- No breaking changes to functionality

## Examples
- `ゲームを開始します` → `new game started\!`
- `ディレクトリが見つかりません` → `no such directory`
- `ファイル一覧:` → `directory listing:`

🤖 Generated with [Claude Code](https://claude.ai/code)