### PR TITLE
feat: 一時ステータスシステムの実装（Issue #24）

### DIFF
--- a/src/player/Stats.test.ts
+++ b/src/player/Stats.test.ts
@@ -1,4 +1,5 @@
 import { Stats } from './Stats';
+import { TemporaryStatus } from './TemporaryStatus';
 
 describe('Stats', () => {
   describe('初期化', () => {
@@ -227,6 +228,7 @@ describe('Stats', () => {
           accuracy: 0,
           fortune: 0,
         },
+        temporaryStatuses: [],
       });
     });
 
@@ -282,6 +284,215 @@ describe('Stats', () => {
       stats.applyTemporaryBoost('attack', -999);
 
       expect(stats.getAttack()).toBe(0); // 負の値にはならない
+    });
+  });
+
+  describe('一時ステータス管理システム', () => {
+    describe('addTemporaryStatus', () => {
+      test('一時ステータスを追加する', () => {
+        const stats = new Stats(1);
+        const status: TemporaryStatus = {
+          id: 'buff-attack-001',
+          name: '攻撃力アップ',
+          type: 'buff',
+          effects: { attack: 10 },
+          duration: 3,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(status);
+        const statuses = stats.getTemporaryStatuses();
+
+        expect(statuses).toHaveLength(1);
+        expect(statuses[0]).toEqual(status);
+      });
+
+      test('同じIDの一時ステータスは上書きされる', () => {
+        const stats = new Stats(1);
+        const status1: TemporaryStatus = {
+          id: 'same-id',
+          name: '最初の効果',
+          type: 'buff',
+          effects: { attack: 5 },
+          duration: 2,
+          stackable: false,
+        };
+        const status2: TemporaryStatus = {
+          id: 'same-id',
+          name: '上書きする効果',
+          type: 'buff',
+          effects: { attack: 10 },
+          duration: 4,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(status1);
+        stats.addTemporaryStatus(status2);
+        const statuses = stats.getTemporaryStatuses();
+
+        expect(statuses).toHaveLength(1);
+        expect(statuses[0].name).toBe('上書きする効果');
+        expect(statuses[0].effects.attack).toBe(10);
+      });
+
+      test('stackable=falseの同じ名前の効果は上書きされる', () => {
+        const stats = new Stats(1);
+        const status1: TemporaryStatus = {
+          id: 'attack-buff-1',
+          name: '攻撃力アップ',
+          type: 'buff',
+          effects: { attack: 5 },
+          duration: 2,
+          stackable: false,
+        };
+        const status2: TemporaryStatus = {
+          id: 'attack-buff-2',
+          name: '攻撃力アップ',
+          type: 'buff',
+          effects: { attack: 8 },
+          duration: 3,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(status1);
+        stats.addTemporaryStatus(status2);
+        const statuses = stats.getTemporaryStatuses();
+
+        expect(statuses).toHaveLength(1);
+        expect(statuses[0].id).toBe('attack-buff-2');
+        expect(statuses[0].effects.attack).toBe(8);
+      });
+
+      test('stackable=trueの同じ名前の効果は両方保持される', () => {
+        const stats = new Stats(1);
+        const status1: TemporaryStatus = {
+          id: 'stack-1',
+          name: 'スタック可能効果',
+          type: 'buff',
+          effects: { attack: 3 },
+          duration: 2,
+          stackable: true,
+        };
+        const status2: TemporaryStatus = {
+          id: 'stack-2',
+          name: 'スタック可能効果',
+          type: 'buff',
+          effects: { attack: 4 },
+          duration: 3,
+          stackable: true,
+        };
+
+        stats.addTemporaryStatus(status1);
+        stats.addTemporaryStatus(status2);
+        const statuses = stats.getTemporaryStatuses();
+
+        expect(statuses).toHaveLength(2);
+        expect(statuses.find(s => s.id === 'stack-1')).toBeDefined();
+        expect(statuses.find(s => s.id === 'stack-2')).toBeDefined();
+      });
+    });
+
+    describe('removeTemporaryStatus', () => {
+      test('指定されたIDの一時ステータスを削除する', () => {
+        const stats = new Stats(1);
+        const status1: TemporaryStatus = {
+          id: 'remove-test-1',
+          name: '削除テスト1',
+          type: 'buff',
+          effects: { attack: 5 },
+          duration: 3,
+          stackable: false,
+        };
+        const status2: TemporaryStatus = {
+          id: 'remove-test-2',
+          name: '削除テスト2',
+          type: 'buff',
+          effects: { defense: 3 },
+          duration: 2,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(status1);
+        stats.addTemporaryStatus(status2);
+        expect(stats.getTemporaryStatuses()).toHaveLength(2);
+
+        stats.removeTemporaryStatus('remove-test-1');
+        const statuses = stats.getTemporaryStatuses();
+
+        expect(statuses).toHaveLength(1);
+        expect(statuses[0].id).toBe('remove-test-2');
+      });
+
+      test('存在しないIDを指定しても例外が発生しない', () => {
+        const stats = new Stats(1);
+
+        expect(() => {
+          stats.removeTemporaryStatus('non-existent-id');
+        }).not.toThrow();
+      });
+    });
+
+    describe('getTemporaryStatuses', () => {
+      test('一時ステータスの配列を取得する', () => {
+        const stats = new Stats(1);
+        const status: TemporaryStatus = {
+          id: 'get-test',
+          name: '取得テスト',
+          type: 'debuff',
+          effects: { speed: -2 },
+          duration: 1,
+          stackable: false,
+        };
+
+        expect(stats.getTemporaryStatuses()).toEqual([]);
+
+        stats.addTemporaryStatus(status);
+        expect(stats.getTemporaryStatuses()).toEqual([status]);
+      });
+    });
+
+    describe('getActiveStatusAilments', () => {
+      test('状態異常のみを取得する', () => {
+        const stats = new Stats(1);
+        const buff: TemporaryStatus = {
+          id: 'buff-test',
+          name: 'バフテスト',
+          type: 'buff',
+          effects: { attack: 5 },
+          duration: 3,
+          stackable: false,
+        };
+        const ailment: TemporaryStatus = {
+          id: 'poison-test',
+          name: '毒',
+          type: 'status_ailment',
+          effects: { hpPerTurn: -2 },
+          duration: 4,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(buff);
+        stats.addTemporaryStatus(ailment);
+
+        const ailments = stats.getActiveStatusAilments();
+        expect(ailments).toHaveLength(1);
+        expect(ailments[0].id).toBe('poison-test');
+      });
+
+      test('状態異常がない場合は空の配列を返す', () => {
+        const stats = new Stats(1);
+        const buff: TemporaryStatus = {
+          id: 'buff-only',
+          name: 'バフのみ',
+          type: 'buff',
+          effects: { attack: 5 },
+          duration: 3,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(buff);
+        expect(stats.getActiveStatusAilments()).toEqual([]);
+      });
     });
   });
 });

--- a/src/player/Stats.test.ts
+++ b/src/player/Stats.test.ts
@@ -1,4 +1,4 @@
-import { Stats } from './Stats';
+import { Stats, TotalStats } from './Stats';
 import { TemporaryStatus } from './TemporaryStatus';
 
 describe('Stats', () => {
@@ -492,6 +492,221 @@ describe('Stats', () => {
 
         stats.addTemporaryStatus(buff);
         expect(stats.getActiveStatusAilments()).toEqual([]);
+      });
+    });
+  });
+
+  describe('効果計算システム（一時ステータス統合）', () => {
+    describe('getTotalStats', () => {
+      test('基本ステータス + 一時ステータス効果の総和計算', () => {
+        const stats = new Stats(1);
+        const baseAttack = stats.getAttack();
+        const baseDefense = stats.getDefense();
+
+        const buff: TemporaryStatus = {
+          id: 'total-test-1',
+          name: '総合バフ',
+          type: 'buff',
+          effects: {
+            attack: 15,
+            defense: 10,
+          },
+          duration: 3,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(buff);
+        const totalStats: TotalStats = stats.getTotalStats();
+
+        expect(totalStats.attack).toBe(baseAttack + 15);
+        expect(totalStats.defense).toBe(baseDefense + 10);
+        expect(totalStats.speed).toBe(stats.getSpeed()); // 変更なし
+      });
+
+      test('複数バフ/デバフの重ね合わせ', () => {
+        const stats = new Stats(1);
+        const baseAttack = stats.getAttack();
+
+        const buff1: TemporaryStatus = {
+          id: 'stack-buff-1',
+          name: 'スタック攻撃バフ1',
+          type: 'buff',
+          effects: { attack: 8 },
+          duration: 3,
+          stackable: true,
+        };
+
+        const buff2: TemporaryStatus = {
+          id: 'stack-buff-2',
+          name: 'スタック攻撃バフ2',
+          type: 'buff',
+          effects: { attack: 5 },
+          duration: 2,
+          stackable: true,
+        };
+
+        const debuff: TemporaryStatus = {
+          id: 'attack-debuff',
+          name: '攻撃デバフ',
+          type: 'debuff',
+          effects: { attack: -3 },
+          duration: 4,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(buff1);
+        stats.addTemporaryStatus(buff2);
+        stats.addTemporaryStatus(debuff);
+
+        const totalStats = stats.getTotalStats();
+        expect(totalStats.attack).toBe(baseAttack + 8 + 5 - 3); // 10 + 8 + 5 - 3 = 20
+      });
+
+      test('状態異常による特殊効果', () => {
+        const stats = new Stats(1);
+        const baseSpeed = stats.getSpeed(); // 一時ステータス追加前の速度を記録
+
+        const poison: TemporaryStatus = {
+          id: 'poison-effect',
+          name: '毒',
+          type: 'status_ailment',
+          effects: {
+            hpPerTurn: -2,
+            cannotRun: true,
+          },
+          duration: 3,
+          stackable: false,
+        };
+
+        const paralysis: TemporaryStatus = {
+          id: 'paralysis-effect',
+          name: '麻痺',
+          type: 'status_ailment',
+          effects: {
+            cannotAct: true,
+            speed: -5,
+          },
+          duration: 2,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(poison);
+        stats.addTemporaryStatus(paralysis);
+
+        const totalStats = stats.getTotalStats();
+        expect(totalStats.hpPerTurn).toBe(-2);
+        expect(totalStats.cannotRun).toBe(true);
+        expect(totalStats.cannotAct).toBe(true);
+        expect(totalStats.speed).toBe(Math.max(0, baseSpeed - 5)); // 負にならない
+      });
+
+      test('負の値にならないことを確認', () => {
+        const stats = new Stats(1);
+
+        const majorDebuff: TemporaryStatus = {
+          id: 'major-debuff',
+          name: '大デバフ',
+          type: 'debuff',
+          effects: {
+            attack: -999,
+            defense: -999,
+          },
+          duration: 2,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(majorDebuff);
+        const totalStats = stats.getTotalStats();
+
+        expect(totalStats.attack).toBe(0); // 負にならない
+        expect(totalStats.defense).toBe(0); // 負にならない
+      });
+    });
+
+    describe('一時ステータス反映ゲッターメソッド', () => {
+      test('getAttackが一時ステータス効果を含む', () => {
+        const stats = new Stats(1);
+        const originalAttack = stats.getAttack();
+
+        const buff: TemporaryStatus = {
+          id: 'attack-test',
+          name: '攻撃バフ',
+          type: 'buff',
+          effects: { attack: 12 },
+          duration: 3,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(buff);
+        expect(stats.getAttack()).toBe(originalAttack + 12);
+      });
+
+      test('getDefenseが一時ステータス効果を含む', () => {
+        const stats = new Stats(1);
+        const originalDefense = stats.getDefense();
+
+        const debuff: TemporaryStatus = {
+          id: 'defense-test',
+          name: '防御デバフ',
+          type: 'debuff',
+          effects: { defense: -4 },
+          duration: 2,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(debuff);
+        expect(stats.getDefense()).toBe(Math.max(0, originalDefense - 4));
+      });
+
+      test('getSpeedが一時ステータス効果を含む', () => {
+        const stats = new Stats(1);
+        const originalSpeed = stats.getSpeed();
+
+        const speedBuff: TemporaryStatus = {
+          id: 'speed-test',
+          name: 'スピードアップ',
+          type: 'buff',
+          effects: { speed: 7 },
+          duration: 4,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(speedBuff);
+        expect(stats.getSpeed()).toBe(originalSpeed + 7);
+      });
+
+      test('getAccuracyが一時ステータス効果を含む', () => {
+        const stats = new Stats(1);
+        const originalAccuracy = stats.getAccuracy();
+
+        const accuracyBuff: TemporaryStatus = {
+          id: 'accuracy-test',
+          name: '命中アップ',
+          type: 'buff',
+          effects: { accuracy: 5 },
+          duration: 3,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(accuracyBuff);
+        expect(stats.getAccuracy()).toBe(originalAccuracy + 5);
+      });
+
+      test('getFortuneが一時ステータス効果を含む', () => {
+        const stats = new Stats(1);
+        const originalFortune = stats.getFortune();
+
+        const fortuneDebuff: TemporaryStatus = {
+          id: 'fortune-test',
+          name: '運気ダウン',
+          type: 'debuff',
+          effects: { fortune: -2 },
+          duration: 2,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(fortuneDebuff);
+        expect(stats.getFortune()).toBe(Math.max(0, originalFortune - 2));
       });
     });
   });

--- a/src/player/Stats.test.ts
+++ b/src/player/Stats.test.ts
@@ -1,5 +1,5 @@
 import { Stats, TotalStats } from './Stats';
-import { TemporaryStatus } from './TemporaryStatus';
+import { TemporaryStatus, TemporaryStatusName } from './TemporaryStatus';
 
 describe('Stats', () => {
   describe('初期化', () => {
@@ -293,7 +293,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const status: TemporaryStatus = {
           id: 'buff-attack-001',
-          name: '攻撃力アップ',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 10 },
           duration: 3,
@@ -311,7 +311,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const status1: TemporaryStatus = {
           id: 'same-id',
-          name: '最初の効果',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 5 },
           duration: 2,
@@ -319,7 +319,7 @@ describe('Stats', () => {
         };
         const status2: TemporaryStatus = {
           id: 'same-id',
-          name: '上書きする効果',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 10 },
           duration: 4,
@@ -331,7 +331,7 @@ describe('Stats', () => {
         const statuses = stats.getTemporaryStatuses();
 
         expect(statuses).toHaveLength(1);
-        expect(statuses[0].name).toBe('上書きする効果');
+        expect(statuses[0].name).toBe('Attack Up');
         expect(statuses[0].effects.attack).toBe(10);
       });
 
@@ -339,7 +339,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const status1: TemporaryStatus = {
           id: 'attack-buff-1',
-          name: '攻撃力アップ',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 5 },
           duration: 2,
@@ -347,7 +347,7 @@ describe('Stats', () => {
         };
         const status2: TemporaryStatus = {
           id: 'attack-buff-2',
-          name: '攻撃力アップ',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 8 },
           duration: 3,
@@ -367,7 +367,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const status1: TemporaryStatus = {
           id: 'stack-1',
-          name: 'スタック可能効果',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 3 },
           duration: 2,
@@ -375,7 +375,7 @@ describe('Stats', () => {
         };
         const status2: TemporaryStatus = {
           id: 'stack-2',
-          name: 'スタック可能効果',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 4 },
           duration: 3,
@@ -397,7 +397,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const status1: TemporaryStatus = {
           id: 'remove-test-1',
-          name: '削除テスト1',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 5 },
           duration: 3,
@@ -405,7 +405,7 @@ describe('Stats', () => {
         };
         const status2: TemporaryStatus = {
           id: 'remove-test-2',
-          name: '削除テスト2',
+          name: 'Defense Up',
           type: 'buff',
           effects: { defense: 3 },
           duration: 2,
@@ -437,7 +437,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const status: TemporaryStatus = {
           id: 'get-test',
-          name: '取得テスト',
+          name: 'Speed Up',
           type: 'debuff',
           effects: { speed: -2 },
           duration: 1,
@@ -456,7 +456,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const buff: TemporaryStatus = {
           id: 'buff-test',
-          name: 'バフテスト',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 5 },
           duration: 3,
@@ -464,7 +464,7 @@ describe('Stats', () => {
         };
         const ailment: TemporaryStatus = {
           id: 'poison-test',
-          name: '毒',
+          name: 'Poison',
           type: 'status_ailment',
           effects: { hpPerTurn: -2 },
           duration: 4,
@@ -483,7 +483,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const buff: TemporaryStatus = {
           id: 'buff-only',
-          name: 'バフのみ',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 5 },
           duration: 3,
@@ -505,7 +505,7 @@ describe('Stats', () => {
 
         const buff: TemporaryStatus = {
           id: 'total-test-1',
-          name: '総合バフ',
+          name: 'All Stats Up',
           type: 'buff',
           effects: {
             attack: 15,
@@ -529,7 +529,7 @@ describe('Stats', () => {
 
         const buff1: TemporaryStatus = {
           id: 'stack-buff-1',
-          name: 'スタック攻撃バフ1',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 8 },
           duration: 3,
@@ -538,7 +538,7 @@ describe('Stats', () => {
 
         const buff2: TemporaryStatus = {
           id: 'stack-buff-2',
-          name: 'スタック攻撃バフ2',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 5 },
           duration: 2,
@@ -547,7 +547,7 @@ describe('Stats', () => {
 
         const debuff: TemporaryStatus = {
           id: 'attack-debuff',
-          name: '攻撃デバフ',
+          name: 'Attack Down',
           type: 'debuff',
           effects: { attack: -3 },
           duration: 4,
@@ -568,7 +568,7 @@ describe('Stats', () => {
 
         const poison: TemporaryStatus = {
           id: 'poison-effect',
-          name: '毒',
+          name: 'Poison',
           type: 'status_ailment',
           effects: {
             hpPerTurn: -2,
@@ -580,7 +580,7 @@ describe('Stats', () => {
 
         const paralysis: TemporaryStatus = {
           id: 'paralysis-effect',
-          name: '麻痺',
+          name: 'Paralysis',
           type: 'status_ailment',
           effects: {
             cannotAct: true,
@@ -605,7 +605,7 @@ describe('Stats', () => {
 
         const majorDebuff: TemporaryStatus = {
           id: 'major-debuff',
-          name: '大デバフ',
+          name: 'All Stats Down',
           type: 'debuff',
           effects: {
             attack: -999,
@@ -630,7 +630,7 @@ describe('Stats', () => {
 
         const buff: TemporaryStatus = {
           id: 'attack-test',
-          name: '攻撃バフ',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 12 },
           duration: 3,
@@ -647,7 +647,7 @@ describe('Stats', () => {
 
         const debuff: TemporaryStatus = {
           id: 'defense-test',
-          name: '防御デバフ',
+          name: 'Defense Down',
           type: 'debuff',
           effects: { defense: -4 },
           duration: 2,
@@ -664,7 +664,7 @@ describe('Stats', () => {
 
         const speedBuff: TemporaryStatus = {
           id: 'speed-test',
-          name: 'スピードアップ',
+          name: 'Speed Up',
           type: 'buff',
           effects: { speed: 7 },
           duration: 4,
@@ -681,7 +681,7 @@ describe('Stats', () => {
 
         const accuracyBuff: TemporaryStatus = {
           id: 'accuracy-test',
-          name: '命中アップ',
+          name: 'Accuracy Up',
           type: 'buff',
           effects: { accuracy: 5 },
           duration: 3,
@@ -698,7 +698,7 @@ describe('Stats', () => {
 
         const fortuneDebuff: TemporaryStatus = {
           id: 'fortune-test',
-          name: '運気ダウン',
+          name: 'Fortune Down',
           type: 'debuff',
           effects: { fortune: -2 },
           duration: 2,
@@ -717,7 +717,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const status1: TemporaryStatus = {
           id: 'duration-test-1',
-          name: '期間テスト1',
+          name: 'Attack Up',
           type: 'buff',
           effects: { attack: 5 },
           duration: 3,
@@ -725,7 +725,7 @@ describe('Stats', () => {
         };
         const status2: TemporaryStatus = {
           id: 'duration-test-2',
-          name: '期間テスト2',
+          name: 'Defense Up',
           type: 'buff',
           effects: { defense: 3 },
           duration: 2, // 1だと削除されてしまうため2に変更
@@ -749,7 +749,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const expiredStatus: TemporaryStatus = {
           id: 'expired-test',
-          name: '期限切れテスト',
+          name: 'Speed Up',
           type: 'debuff',
           effects: { attack: -2 },
           duration: 1,
@@ -757,7 +757,7 @@ describe('Stats', () => {
         };
         const activeStatus: TemporaryStatus = {
           id: 'active-test',
-          name: 'アクティブテスト',
+          name: 'Attack Up',
           type: 'buff',
           effects: { defense: 4 },
           duration: 3,
@@ -780,7 +780,7 @@ describe('Stats', () => {
         const stats = new Stats(1);
         const permanentStatus: TemporaryStatus = {
           id: 'permanent-test',
-          name: '永続テスト',
+          name: 'Accuracy Up',
           type: 'buff',
           effects: { fortune: 1 },
           duration: -1,
@@ -788,7 +788,7 @@ describe('Stats', () => {
         };
         const temporaryStatus: TemporaryStatus = {
           id: 'temporary-test',
-          name: '一時テスト',
+          name: 'Fortune Up',
           type: 'buff',
           effects: { speed: 2 },
           duration: 2,
@@ -819,7 +819,7 @@ describe('Stats', () => {
 
         const regenStatus: TemporaryStatus = {
           id: 'regen-turn-test',
-          name: '再生ターンテスト',
+          name: 'Regeneration',
           type: 'buff',
           effects: {
             mpPerTurn: 3, // シンプルにMP変化のみでテスト
@@ -861,7 +861,7 @@ describe('Stats', () => {
 
         const regenStatus: TemporaryStatus = {
           id: 'direct-test',
-          name: '直接テスト',
+          name: 'Regeneration',
           type: 'buff',
           effects: {
             mpPerTurn: 3,
@@ -889,7 +889,7 @@ describe('Stats', () => {
 
         const status: TemporaryStatus = {
           id: 'calc-test',
-          name: '計算テスト',
+          name: 'Regeneration',
           type: 'buff',
           effects: {
             mpPerTurn: 5,
@@ -933,7 +933,7 @@ describe('Stats', () => {
 
         const poison1: TemporaryStatus = {
           id: 'poison-1',
-          name: '毒1',
+          name: 'Poison',
           type: 'status_ailment',
           effects: { hpPerTurn: -3 },
           duration: 2,
@@ -941,7 +941,7 @@ describe('Stats', () => {
         };
         const poison2: TemporaryStatus = {
           id: 'poison-2',
-          name: '毒2',
+          name: 'Burn',
           type: 'status_ailment',
           effects: { hpPerTurn: -2 },
           duration: 3,
@@ -949,7 +949,7 @@ describe('Stats', () => {
         };
         const healing: TemporaryStatus = {
           id: 'healing',
-          name: '回復',
+          name: 'Regeneration',
           type: 'buff',
           effects: { hpPerTurn: 4 },
           duration: 2,
@@ -975,7 +975,7 @@ describe('Stats', () => {
 
         const massiveDamage: TemporaryStatus = {
           id: 'massive-damage',
-          name: '大ダメージ',
+          name: 'Poison',
           type: 'status_ailment',
           effects: { hpPerTurn: -999 },
           duration: 1, // duration を1に変更して次のターンで削除されるようにする
@@ -993,7 +993,7 @@ describe('Stats', () => {
         // 回復テスト
         const massiveHeal: TemporaryStatus = {
           id: 'massive-heal',
-          name: '大回復',
+          name: 'Regeneration',
           type: 'buff',
           effects: {
             hpPerTurn: 999,
@@ -1020,7 +1020,7 @@ describe('Stats', () => {
       // StatusAilmentFactoryが存在しないため、手動で毒ステータスを作成
       const poison: TemporaryStatus = {
         id: 'poison-integration-test',
-        name: '毒',
+        name: 'Poison' as TemporaryStatusName,
         type: 'status_ailment',
         effects: {
           hpPerTurn: -5, // 毎ターン5ダメージ
@@ -1035,7 +1035,7 @@ describe('Stats', () => {
       // 状態異常が正しく追加されているか確認
       const ailments = stats.getActiveStatusAilments();
       expect(ailments).toHaveLength(1);
-      expect(ailments[0].name).toBe('毒');
+      expect(ailments[0].name).toBe('Poison');
 
       // 総合ステータスに状態異常の効果が反映されているか確認
       const totalStats = stats.getTotalStats();
@@ -1065,7 +1065,7 @@ describe('Stats', () => {
       // 毒状態異常
       const poison: TemporaryStatus = {
         id: 'poison-combo-test',
-        name: '毒',
+        name: 'Poison' as TemporaryStatusName,
         type: 'status_ailment',
         effects: { hpPerTurn: -3 },
         duration: 2,
@@ -1075,7 +1075,7 @@ describe('Stats', () => {
       // 再生バフ
       const regen: TemporaryStatus = {
         id: 'regen-combo-test',
-        name: '再生',
+        name: 'Regeneration' as TemporaryStatusName,
         type: 'buff',
         effects: {
           hpPerTurn: 5,
@@ -1088,7 +1088,7 @@ describe('Stats', () => {
       // 麻痺状態異常
       const paralysis: TemporaryStatus = {
         id: 'paralysis-combo-test',
-        name: '麻痺',
+        name: 'Paralysis' as TemporaryStatusName,
         type: 'status_ailment',
         effects: {
           cannotAct: true,
@@ -1112,8 +1112,8 @@ describe('Stats', () => {
       // 状態異常のみ取得
       const ailments = stats.getActiveStatusAilments();
       expect(ailments).toHaveLength(2);
-      expect(ailments.map(a => a.name)).toContain('毒');
-      expect(ailments.map(a => a.name)).toContain('麻痺');
+      expect(ailments.map(a => a.name)).toContain('Poison');
+      expect(ailments.map(a => a.name)).toContain('Paralysis');
 
       // ターン経過で効果適用
       stats.updateTemporaryStatuses();

--- a/src/player/Stats.test.ts
+++ b/src/player/Stats.test.ts
@@ -710,4 +710,417 @@ describe('Stats', () => {
       });
     });
   });
+
+  describe('ターン経過処理システム', () => {
+    describe('updateTemporaryStatuses', () => {
+      test('継続期間の減少', () => {
+        const stats = new Stats(1);
+        const status1: TemporaryStatus = {
+          id: 'duration-test-1',
+          name: '期間テスト1',
+          type: 'buff',
+          effects: { attack: 5 },
+          duration: 3,
+          stackable: false,
+        };
+        const status2: TemporaryStatus = {
+          id: 'duration-test-2',
+          name: '期間テスト2',
+          type: 'buff',
+          effects: { defense: 3 },
+          duration: 2, // 1だと削除されてしまうため2に変更
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(status1);
+        stats.addTemporaryStatus(status2);
+
+        stats.updateTemporaryStatuses();
+        const statuses = stats.getTemporaryStatuses();
+
+        const updatedStatus1 = statuses.find(s => s.id === 'duration-test-1');
+        const updatedStatus2 = statuses.find(s => s.id === 'duration-test-2');
+
+        expect(updatedStatus1?.duration).toBe(2); // 3 → 2
+        expect(updatedStatus2?.duration).toBe(1); // 2 → 1
+      });
+
+      test('期限切れステータスの自動削除', () => {
+        const stats = new Stats(1);
+        const expiredStatus: TemporaryStatus = {
+          id: 'expired-test',
+          name: '期限切れテスト',
+          type: 'debuff',
+          effects: { attack: -2 },
+          duration: 1,
+          stackable: false,
+        };
+        const activeStatus: TemporaryStatus = {
+          id: 'active-test',
+          name: 'アクティブテスト',
+          type: 'buff',
+          effects: { defense: 4 },
+          duration: 3,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(expiredStatus);
+        stats.addTemporaryStatus(activeStatus);
+        expect(stats.getTemporaryStatuses()).toHaveLength(2);
+
+        stats.updateTemporaryStatuses(); // expiredStatus は duration 1 → 0 → 削除
+        const remainingStatuses = stats.getTemporaryStatuses();
+
+        expect(remainingStatuses).toHaveLength(1);
+        expect(remainingStatuses[0].id).toBe('active-test');
+        expect(remainingStatuses[0].duration).toBe(2); // 3 → 2
+      });
+
+      test('永続効果（duration: -1）のテスト', () => {
+        const stats = new Stats(1);
+        const permanentStatus: TemporaryStatus = {
+          id: 'permanent-test',
+          name: '永続テスト',
+          type: 'buff',
+          effects: { fortune: 1 },
+          duration: -1,
+          stackable: false,
+        };
+        const temporaryStatus: TemporaryStatus = {
+          id: 'temporary-test',
+          name: '一時テスト',
+          type: 'buff',
+          effects: { speed: 2 },
+          duration: 2,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(permanentStatus);
+        stats.addTemporaryStatus(temporaryStatus);
+
+        stats.updateTemporaryStatuses();
+        const statuses = stats.getTemporaryStatuses();
+
+        const permanent = statuses.find(s => s.id === 'permanent-test');
+        const temporary = statuses.find(s => s.id === 'temporary-test');
+
+        expect(permanent?.duration).toBe(-1); // 永続効果は変化しない
+        expect(temporary?.duration).toBe(1); // 2 → 1
+      });
+
+      test('毎ターン効果（HP/MP変化）のテスト', () => {
+        const stats = new Stats(1);
+        const initialHP = stats.getCurrentHP();
+        const initialMP = stats.getCurrentMP();
+
+        // デバッグ: 初期値を明示的に確認
+        expect(initialHP).toBe(120); // 100 + (1 × 20)
+        expect(initialMP).toBe(60); // 50 + (1 × 10)
+
+        const regenStatus: TemporaryStatus = {
+          id: 'regen-turn-test',
+          name: '再生ターンテスト',
+          type: 'buff',
+          effects: {
+            mpPerTurn: 3, // シンプルにMP変化のみでテスト
+          },
+          duration: 3,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(regenStatus);
+
+        // 追加されたステータスを確認
+        expect(stats.getTemporaryStatuses()).toHaveLength(1);
+        expect(stats.getTemporaryStatuses()[0].effects.mpPerTurn).toBe(3);
+
+        stats.updateTemporaryStatuses();
+
+        // MPに余裕を作ってからテスト
+        stats.consumeMP(10); // 60 - 10 = 50
+        const currentMP = stats.getCurrentMP();
+        expect(currentMP).toBe(50);
+
+        stats.updateTemporaryStatuses();
+
+        // MP変化: +3 のみでテスト
+        expect(stats.getCurrentMP()).toBe(currentMP + 3); // 50 + 3 = 53
+
+        // ステータスがまだ残っているか確認 (duration: 3 -> 2 -> 1, 2回呼び出したため)
+        expect(stats.getTemporaryStatuses()).toHaveLength(1);
+        expect(stats.getTemporaryStatuses()[0].duration).toBe(1);
+      });
+
+      test('直接applyPerTurnEffectsメソッドのテスト', () => {
+        const stats = new Stats(1);
+
+        // MPに余裕を作る
+        stats.consumeMP(10);
+        const initialMP = stats.getCurrentMP();
+        expect(initialMP).toBe(50); // 60 - 10 = 50
+
+        const regenStatus: TemporaryStatus = {
+          id: 'direct-test',
+          name: '直接テスト',
+          type: 'buff',
+          effects: {
+            mpPerTurn: 3,
+          },
+          duration: 3,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(regenStatus);
+        expect(stats.getTemporaryStatuses()).toHaveLength(1);
+
+        // updateTemporaryStatusesでターン効果が適用されることを確認
+        stats.updateTemporaryStatuses();
+
+        // MPが変化していることを確認
+        expect(stats.getCurrentMP()).toBe(initialMP + 3); // 50 + 3 = 53
+
+        // ステータスはまだ残っている（durationは1減っている）
+        expect(stats.getTemporaryStatuses()).toHaveLength(1);
+        expect(stats.getTemporaryStatuses()[0].duration).toBe(2);
+      });
+
+      test('ステータス効果の計算テスト', () => {
+        const stats = new Stats(1);
+
+        const status: TemporaryStatus = {
+          id: 'calc-test',
+          name: '計算テスト',
+          type: 'buff',
+          effects: {
+            mpPerTurn: 5,
+          },
+          duration: 2,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(status);
+        const statuses = stats.getTemporaryStatuses();
+
+        // ステータスが正しく追加されているか確認
+        expect(statuses).toHaveLength(1);
+        expect(statuses[0].effects.mpPerTurn).toBe(5);
+
+        // 手動で計算してみる
+        let totalMPChange = 0;
+        statuses.forEach(s => {
+          if (s.effects.mpPerTurn) {
+            totalMPChange += s.effects.mpPerTurn;
+          }
+        });
+        expect(totalMPChange).toBe(5);
+
+        // healMPを直接呼び出してみる
+        const beforeMP = stats.getCurrentMP();
+        expect(beforeMP).toBe(60); // 初期値確認
+        const maxMP = stats.getMaxMP();
+        expect(maxMP).toBe(60); // 最大MP確認
+
+        stats.healMP(5);
+        const afterMP = stats.getCurrentMP();
+
+        // 最大MPを超えないことを確認
+        expect(afterMP).toBe(Math.min(maxMP, beforeMP + 5)); // 60が最大なのでMath.min(60, 55) = 55
+      });
+
+      test('複数の毎ターン効果の累積', () => {
+        const stats = new Stats(1);
+        const initialHP = stats.getCurrentHP();
+
+        const poison1: TemporaryStatus = {
+          id: 'poison-1',
+          name: '毒1',
+          type: 'status_ailment',
+          effects: { hpPerTurn: -3 },
+          duration: 2,
+          stackable: true,
+        };
+        const poison2: TemporaryStatus = {
+          id: 'poison-2',
+          name: '毒2',
+          type: 'status_ailment',
+          effects: { hpPerTurn: -2 },
+          duration: 3,
+          stackable: true,
+        };
+        const healing: TemporaryStatus = {
+          id: 'healing',
+          name: '回復',
+          type: 'buff',
+          effects: { hpPerTurn: 4 },
+          duration: 2,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(poison1);
+        stats.addTemporaryStatus(poison2);
+        stats.addTemporaryStatus(healing);
+
+        stats.updateTemporaryStatuses();
+
+        // HP変化: -3 + (-2) + 4 = -1
+        expect(stats.getCurrentHP()).toBe(initialHP - 1);
+      });
+
+      test('HP/MPが0未満および最大値を超えないことを確認', () => {
+        const stats = new Stats(1);
+
+        // HPを1まで減らす
+        stats.takeDamage(stats.getCurrentHP() - 1);
+        expect(stats.getCurrentHP()).toBe(1);
+
+        const massiveDamage: TemporaryStatus = {
+          id: 'massive-damage',
+          name: '大ダメージ',
+          type: 'status_ailment',
+          effects: { hpPerTurn: -999 },
+          duration: 1, // duration を1に変更して次のターンで削除されるようにする
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(massiveDamage);
+        stats.updateTemporaryStatuses();
+
+        expect(stats.getCurrentHP()).toBe(0); // 0未満にならない
+
+        // massiveDamageは削除されているはず
+        expect(stats.getTemporaryStatuses().find(s => s.id === 'massive-damage')).toBeUndefined();
+
+        // 回復テスト
+        const massiveHeal: TemporaryStatus = {
+          id: 'massive-heal',
+          name: '大回復',
+          type: 'buff',
+          effects: {
+            hpPerTurn: 999,
+            mpPerTurn: 999,
+          },
+          duration: 2,
+          stackable: false,
+        };
+
+        stats.addTemporaryStatus(massiveHeal);
+        stats.updateTemporaryStatuses();
+
+        expect(stats.getCurrentHP()).toBe(stats.getMaxHP()); // 最大値を超えない
+        expect(stats.getCurrentMP()).toBe(stats.getMaxMP()); // 最大値を超えない
+      });
+    });
+  });
+
+  describe('状態異常システム統合テスト', () => {
+    test('状態異常ファクトリーとの統合', () => {
+      const stats = new Stats(1);
+      const initialHP = stats.getCurrentHP();
+
+      // StatusAilmentFactoryが存在しないため、手動で毒ステータスを作成
+      const poison: TemporaryStatus = {
+        id: 'poison-integration-test',
+        name: '毒',
+        type: 'status_ailment',
+        effects: {
+          hpPerTurn: -5, // 毎ターン5ダメージ
+          cannotRun: true, // 逃走不可
+        },
+        duration: 3,
+        stackable: false,
+      };
+
+      stats.addTemporaryStatus(poison);
+
+      // 状態異常が正しく追加されているか確認
+      const ailments = stats.getActiveStatusAilments();
+      expect(ailments).toHaveLength(1);
+      expect(ailments[0].name).toBe('毒');
+
+      // 総合ステータスに状態異常の効果が反映されているか確認
+      const totalStats = stats.getTotalStats();
+      expect(totalStats.cannotRun).toBe(true);
+      expect(totalStats.hpPerTurn).toBe(-5);
+
+      // ターン経過で毒ダメージが適用されるか確認
+      stats.updateTemporaryStatuses();
+      expect(stats.getCurrentHP()).toBe(initialHP - 5); // 毒ダメージ適用
+
+      // 継続期間が減っているか確認
+      const remainingStatuses = stats.getTemporaryStatuses();
+      expect(remainingStatuses).toHaveLength(1);
+      expect(remainingStatuses[0].duration).toBe(2); // 3 -> 2
+    });
+
+    test('複数の状態異常とバフの組み合わせ', () => {
+      const stats = new Stats(2); // レベル2でテスト
+
+      // HPにMPに余裕を作る
+      stats.takeDamage(10);
+      stats.consumeMP(15);
+
+      const initialHP = stats.getCurrentHP();
+      const initialMP = stats.getCurrentMP();
+
+      // 毒状態異常
+      const poison: TemporaryStatus = {
+        id: 'poison-combo-test',
+        name: '毒',
+        type: 'status_ailment',
+        effects: { hpPerTurn: -3 },
+        duration: 2,
+        stackable: false,
+      };
+
+      // 再生バフ
+      const regen: TemporaryStatus = {
+        id: 'regen-combo-test',
+        name: '再生',
+        type: 'buff',
+        effects: {
+          hpPerTurn: 5,
+          mpPerTurn: 2,
+        },
+        duration: 3,
+        stackable: false,
+      };
+
+      // 麻痺状態異常
+      const paralysis: TemporaryStatus = {
+        id: 'paralysis-combo-test',
+        name: '麻痺',
+        type: 'status_ailment',
+        effects: {
+          cannotAct: true,
+          speed: -3,
+        },
+        duration: 2,
+        stackable: false,
+      };
+
+      stats.addTemporaryStatus(poison);
+      stats.addTemporaryStatus(regen);
+      stats.addTemporaryStatus(paralysis);
+
+      // 総合ステータスで効果の組み合わせを確認
+      const totalStats = stats.getTotalStats();
+      expect(totalStats.hpPerTurn).toBe(2); // -3 + 5 = 2
+      expect(totalStats.mpPerTurn).toBe(2);
+      expect(totalStats.cannotAct).toBe(true);
+      expect(totalStats.speed).toBe(7); // レベル2の基本速度(10) - 麻痺効果(-3) = 7
+
+      // 状態異常のみ取得
+      const ailments = stats.getActiveStatusAilments();
+      expect(ailments).toHaveLength(2);
+      expect(ailments.map(a => a.name)).toContain('毒');
+      expect(ailments.map(a => a.name)).toContain('麻痺');
+
+      // ターン経過で効果適用
+      stats.updateTemporaryStatuses();
+
+      // HPとMPの変化を確認
+      expect(stats.getCurrentHP()).toBe(initialHP + 2); // 毒ダメージと再生の結果
+      expect(stats.getCurrentMP()).toBe(initialMP + 2); // 再生のMP回復
+    });
+  });
 });

--- a/src/player/Stats.ts
+++ b/src/player/Stats.ts
@@ -291,6 +291,59 @@ export class Stats {
   }
 
   /**
+   * ターン経過処理を実行する
+   * 継続期間を減らし、期限切れステータスを削除し、毎ターン効果を適用する
+   */
+  updateTemporaryStatuses(): void {
+    // 毎ターン効果を先に適用
+    this.applyPerTurnEffects();
+
+    // 継続期間を減らし、期限切れステータスを削除
+    this.temporaryStatuses = this.temporaryStatuses
+      .map(status => {
+        // 永続効果（duration: -1）は変更しない
+        if (status.duration === -1) {
+          return status;
+        }
+        // 継続期間を1減らす
+        return { ...status, duration: status.duration - 1 };
+      })
+      .filter(status => status.duration !== 0); // duration が 0 になったものを削除
+  }
+
+  /**
+   * 毎ターン効果（HP/MP変化）を適用する
+   */
+  private applyPerTurnEffects(): void {
+    let totalHPChange = 0;
+    let totalMPChange = 0;
+
+    // 全ての一時ステータスから毎ターン効果を集計
+    this.temporaryStatuses.forEach(status => {
+      if (status.effects.hpPerTurn) {
+        totalHPChange += status.effects.hpPerTurn;
+      }
+      if (status.effects.mpPerTurn) {
+        totalMPChange += status.effects.mpPerTurn;
+      }
+    });
+
+    // HP変化を適用
+    if (totalHPChange > 0) {
+      this.healHP(totalHPChange);
+    } else if (totalHPChange < 0) {
+      this.takeDamage(-totalHPChange);
+    }
+
+    // MP変化を適用
+    if (totalMPChange > 0) {
+      this.healMP(totalMPChange);
+    } else if (totalMPChange < 0) {
+      this.consumeMP(-totalMPChange);
+    }
+  }
+
+  /**
    * 指定されたステータスの一時ステータス効果の総和を計算する
    * @param statType - ステータスタイプ
    * @returns 効果の総和

--- a/src/player/Stats.ts
+++ b/src/player/Stats.ts
@@ -1,4 +1,4 @@
-import { TemporaryStatus } from './TemporaryStatus';
+import { TemporaryStatus, isTemporaryStatus } from './TemporaryStatus';
 
 /**
  * プレイヤーのステータス管理クラス
@@ -362,35 +362,81 @@ export class Stats {
    * @returns 総合ステータス
    */
   getTotalStats(): TotalStats {
-    const result: TotalStats = {
-      attack: this.getAttack(),
-      defense: this.getDefense(),
-      speed: this.getSpeed(),
-      accuracy: this.getAccuracy(),
-      fortune: this.getFortune(),
-      hpPerTurn: 0,
-      mpPerTurn: 0,
-      cannotAct: false,
-      cannotRun: false,
+    const effects = this.aggregateTemporaryEffects();
+
+    return {
+      attack: Math.max(0, this.baseAttack + this.temporaryBoosts.attack + effects.stats.attack),
+      defense: Math.max(0, this.baseDefense + this.temporaryBoosts.defense + effects.stats.defense),
+      speed: Math.max(0, this.baseSpeed + this.temporaryBoosts.speed + effects.stats.speed),
+      accuracy: Math.max(
+        0,
+        this.baseAccuracy + this.temporaryBoosts.accuracy + effects.stats.accuracy
+      ),
+      fortune: Math.max(0, this.baseFortune + this.temporaryBoosts.fortune + effects.stats.fortune),
+      hpPerTurn: effects.turn.hpPerTurn,
+      mpPerTurn: effects.turn.mpPerTurn,
+      cannotAct: effects.flags.cannotAct,
+      cannotRun: effects.flags.cannotRun,
     };
+  }
 
-    // 特殊効果（ターンごとのHP/MP変化、状態異常効果）を計算
-    this.temporaryStatuses.forEach(status => {
-      if (status.effects.hpPerTurn) {
-        result.hpPerTurn += status.effects.hpPerTurn;
-      }
-      if (status.effects.mpPerTurn) {
-        result.mpPerTurn += status.effects.mpPerTurn;
-      }
-      if (status.effects.cannotAct) {
-        result.cannotAct = true;
-      }
-      if (status.effects.cannotRun) {
-        result.cannotRun = true;
-      }
-    });
+  /**
+   * 全ての一時ステータスからの効果を集約する
+   * @returns 集約された効果
+   */
+  private aggregateTemporaryEffects() {
+    const statEffects = { attack: 0, defense: 0, speed: 0, accuracy: 0, fortune: 0 };
+    const turnEffects = { hpPerTurn: 0, mpPerTurn: 0 };
+    const flagEffects = { cannotAct: false, cannotRun: false };
 
-    return result;
+    for (const status of this.temporaryStatuses) {
+      this.applyStatEffects(status, statEffects);
+      this.applyTurnEffects(status, turnEffects);
+      this.applyFlagEffects(status, flagEffects);
+    }
+
+    return {
+      stats: statEffects,
+      turn: turnEffects,
+      flags: flagEffects,
+    };
+  }
+
+  /**
+   * 一時ステータスからステータス効果を適用する
+   * @param status - 一時ステータス
+   * @param effects - 適用先の効果オブジェクト
+   */
+  private applyStatEffects(status: TemporaryStatus, effects: any) {
+    effects.attack += status.effects.attack || 0;
+    effects.defense += status.effects.defense || 0;
+    effects.speed += status.effects.speed || 0;
+    effects.accuracy += status.effects.accuracy || 0;
+    effects.fortune += status.effects.fortune || 0;
+  }
+
+  /**
+   * 一時ステータスからターン効果を適用する
+   * @param status - 一時ステータス
+   * @param effects - 適用先の効果オブジェクト
+   */
+  private applyTurnEffects(status: TemporaryStatus, effects: any) {
+    effects.hpPerTurn += status.effects.hpPerTurn || 0;
+    effects.mpPerTurn += status.effects.mpPerTurn || 0;
+  }
+
+  /**
+   * 一時ステータスからフラグ効果を適用する
+   * @param status - 一時ステータス
+   * @param effects - 適用先の効果オブジェクト
+   */
+  private applyFlagEffects(status: TemporaryStatus, effects: any) {
+    if (status.effects.cannotAct) {
+      effects.cannotAct = true;
+    }
+    if (status.effects.cannotRun) {
+      effects.cannotRun = true;
+    }
   }
 
   /**
@@ -433,7 +479,7 @@ export class Stats {
     stats.baseFortune = data.baseFortune;
     stats.temporaryBoosts = { ...data.temporaryBoosts };
     stats.temporaryStatuses = data.temporaryStatuses
-      ? data.temporaryStatuses.map((status: any) => ({ ...status }))
+      ? data.temporaryStatuses.filter((status: any) => isTemporaryStatus(status))
       : [];
 
     return stats;

--- a/src/player/Stats.ts
+++ b/src/player/Stats.ts
@@ -1,7 +1,9 @@
+import { TemporaryStatus } from './TemporaryStatus';
+
 /**
  * プレイヤーのステータス管理クラス
  * HP、MP、攻撃力、防御力、速度、精度、幸運を管理し、
- * ダメージ・回復処理、バフ・デバフ処理、JSONシリアライゼーションを提供する
+ * ダメージ・回復処理、一時ステータス処理、JSONシリアライゼーションを提供する
  */
 export class Stats {
   // ゲームバランスパラメータ定数
@@ -26,6 +28,7 @@ export class Stats {
     accuracy: number;
     fortune: number;
   };
+  private temporaryStatuses: TemporaryStatus[];
 
   /**
    * Statsクラスのコンストラクタ
@@ -45,6 +48,7 @@ export class Stats {
       accuracy: 0,
       fortune: 0,
     };
+    this.temporaryStatuses = [];
 
     // HP/MPを最大値で初期化
     this.currentHP = this.calculateMaxHP();
@@ -232,6 +236,56 @@ export class Stats {
   }
 
   /**
+   * 一時ステータスを追加する
+   * 同じIDまたは非スタック可能な同名ステータスは上書きされる
+   * @param status - 追加する一時ステータス
+   */
+  addTemporaryStatus(status: TemporaryStatus): void {
+    // 同じIDが存在する場合は上書き
+    const existingIndex = this.temporaryStatuses.findIndex(s => s.id === status.id);
+    if (existingIndex !== -1) {
+      this.temporaryStatuses[existingIndex] = { ...status };
+      return;
+    }
+
+    // stackable=falseの場合、同じ名前の効果は上書き
+    if (!status.stackable) {
+      const sameNameIndex = this.temporaryStatuses.findIndex(s => s.name === status.name);
+      if (sameNameIndex !== -1) {
+        this.temporaryStatuses[sameNameIndex] = { ...status };
+        return;
+      }
+    }
+
+    // 新しいステータスを追加
+    this.temporaryStatuses.push({ ...status });
+  }
+
+  /**
+   * 指定されたIDの一時ステータスを削除する
+   * @param id - 削除する一時ステータスのID
+   */
+  removeTemporaryStatus(id: string): void {
+    this.temporaryStatuses = this.temporaryStatuses.filter(status => status.id !== id);
+  }
+
+  /**
+   * 全ての一時ステータスを取得する
+   * @returns 一時ステータスの配列
+   */
+  getTemporaryStatuses(): TemporaryStatus[] {
+    return [...this.temporaryStatuses];
+  }
+
+  /**
+   * 状態異常のみを取得する
+   * @returns 状態異常の配列
+   */
+  getActiveStatusAilments(): TemporaryStatus[] {
+    return this.temporaryStatuses.filter(status => status.type === 'status_ailment');
+  }
+
+  /**
    * StatsオブジェクトをJSONに変換する
    * @returns JSON形式のデータ
    */
@@ -246,6 +300,7 @@ export class Stats {
       baseAccuracy: this.baseAccuracy,
       baseFortune: this.baseFortune,
       temporaryBoosts: { ...this.temporaryBoosts },
+      temporaryStatuses: this.temporaryStatuses.map(status => ({ ...status })),
     };
   }
 
@@ -269,6 +324,9 @@ export class Stats {
     stats.baseAccuracy = data.baseAccuracy;
     stats.baseFortune = data.baseFortune;
     stats.temporaryBoosts = { ...data.temporaryBoosts };
+    stats.temporaryStatuses = data.temporaryStatuses
+      ? data.temporaryStatuses.map((status: any) => ({ ...status }))
+      : [];
 
     return stats;
   }
@@ -356,4 +414,5 @@ export interface StatsData {
     accuracy: number;
     fortune: number;
   };
+  temporaryStatuses?: TemporaryStatus[];
 }

--- a/src/player/Stats.ts
+++ b/src/player/Stats.ts
@@ -106,43 +106,48 @@ export class Stats {
   }
 
   /**
-   * 攻撃力を取得する（基本値 + 一時的なブースト）
+   * 攻撃力を取得する（基本値 + 一時的なブースト + 一時ステータス効果）
    * @returns 攻撃力
    */
   getAttack(): number {
-    return Math.max(0, this.baseAttack + this.temporaryBoosts.attack);
+    const temporaryStatusBonus = this.calculateTemporaryStatusEffect('attack');
+    return Math.max(0, this.baseAttack + this.temporaryBoosts.attack + temporaryStatusBonus);
   }
 
   /**
-   * 防御力を取得する（基本値 + 一時的なブースト）
+   * 防御力を取得する（基本値 + 一時的なブースト + 一時ステータス効果）
    * @returns 防御力
    */
   getDefense(): number {
-    return Math.max(0, this.baseDefense + this.temporaryBoosts.defense);
+    const temporaryStatusBonus = this.calculateTemporaryStatusEffect('defense');
+    return Math.max(0, this.baseDefense + this.temporaryBoosts.defense + temporaryStatusBonus);
   }
 
   /**
-   * 速度を取得する（基本値 + 一時的なブースト）
+   * 速度を取得する（基本値 + 一時的なブースト + 一時ステータス効果）
    * @returns 速度
    */
   getSpeed(): number {
-    return Math.max(0, this.baseSpeed + this.temporaryBoosts.speed);
+    const temporaryStatusBonus = this.calculateTemporaryStatusEffect('speed');
+    return Math.max(0, this.baseSpeed + this.temporaryBoosts.speed + temporaryStatusBonus);
   }
 
   /**
-   * 精度を取得する（基本値 + 一時的なブースト）
+   * 精度を取得する（基本値 + 一時的なブースト + 一時ステータス効果）
    * @returns 精度
    */
   getAccuracy(): number {
-    return Math.max(0, this.baseAccuracy + this.temporaryBoosts.accuracy);
+    const temporaryStatusBonus = this.calculateTemporaryStatusEffect('accuracy');
+    return Math.max(0, this.baseAccuracy + this.temporaryBoosts.accuracy + temporaryStatusBonus);
   }
 
   /**
-   * 幸運を取得する（基本値 + 一時的なブースト）
+   * 幸運を取得する（基本値 + 一時的なブースト + 一時ステータス効果）
    * @returns 幸運
    */
   getFortune(): number {
-    return Math.max(0, this.baseFortune + this.temporaryBoosts.fortune);
+    const temporaryStatusBonus = this.calculateTemporaryStatusEffect('fortune');
+    return Math.max(0, this.baseFortune + this.temporaryBoosts.fortune + temporaryStatusBonus);
   }
 
   /**
@@ -286,6 +291,56 @@ export class Stats {
   }
 
   /**
+   * 指定されたステータスの一時ステータス効果の総和を計算する
+   * @param statType - ステータスタイプ
+   * @returns 効果の総和
+   */
+  private calculateTemporaryStatusEffect(
+    statType: 'attack' | 'defense' | 'speed' | 'accuracy' | 'fortune'
+  ): number {
+    return this.temporaryStatuses.reduce((total, status) => {
+      const effect = status.effects[statType];
+      return total + (effect || 0);
+    }, 0);
+  }
+
+  /**
+   * 全ての一時ステータス効果を含む総合ステータスを取得する
+   * @returns 総合ステータス
+   */
+  getTotalStats(): TotalStats {
+    const result: TotalStats = {
+      attack: this.getAttack(),
+      defense: this.getDefense(),
+      speed: this.getSpeed(),
+      accuracy: this.getAccuracy(),
+      fortune: this.getFortune(),
+      hpPerTurn: 0,
+      mpPerTurn: 0,
+      cannotAct: false,
+      cannotRun: false,
+    };
+
+    // 特殊効果（ターンごとのHP/MP変化、状態異常効果）を計算
+    this.temporaryStatuses.forEach(status => {
+      if (status.effects.hpPerTurn) {
+        result.hpPerTurn += status.effects.hpPerTurn;
+      }
+      if (status.effects.mpPerTurn) {
+        result.mpPerTurn += status.effects.mpPerTurn;
+      }
+      if (status.effects.cannotAct) {
+        result.cannotAct = true;
+      }
+      if (status.effects.cannotRun) {
+        result.cannotRun = true;
+      }
+    });
+
+    return result;
+  }
+
+  /**
    * StatsオブジェクトをJSONに変換する
    * @returns JSON形式のデータ
    */
@@ -415,4 +470,19 @@ export interface StatsData {
     fortune: number;
   };
   temporaryStatuses?: TemporaryStatus[];
+}
+
+/**
+ * 一時ステータス効果を含む総合ステータス
+ */
+export interface TotalStats {
+  attack: number;
+  defense: number;
+  speed: number;
+  accuracy: number;
+  fortune: number;
+  hpPerTurn: number;
+  mpPerTurn: number;
+  cannotAct: boolean;
+  cannotRun: boolean;
 }

--- a/src/player/StatusAilmentFactory.test.ts
+++ b/src/player/StatusAilmentFactory.test.ts
@@ -7,7 +7,7 @@ describe('StatusAilmentFactory', () => {
       test('デフォルト値で毒状態異常を生成する', () => {
         const poison = StatusAilmentFactory.createPoison();
 
-        expect(poison.name).toBe('毒');
+        expect(poison.name).toBe('Poison');
         expect(poison.type).toBe('status_ailment');
         expect(poison.effects.hpPerTurn).toBe(-3); // デフォルトダメージ
         expect(poison.effects.cannotRun).toBe(true);
@@ -34,7 +34,7 @@ describe('StatusAilmentFactory', () => {
       test('デフォルト値で麻痺状態異常を生成する', () => {
         const paralysis = StatusAilmentFactory.createParalysis();
 
-        expect(paralysis.name).toBe('麻痺');
+        expect(paralysis.name).toBe('Paralysis');
         expect(paralysis.type).toBe('status_ailment');
         expect(paralysis.effects.cannotAct).toBe(true);
         expect(paralysis.effects.speed).toBe(-5);
@@ -54,7 +54,7 @@ describe('StatusAilmentFactory', () => {
       test('デフォルト値で睡眠状態異常を生成する', () => {
         const sleep = StatusAilmentFactory.createSleep();
 
-        expect(sleep.name).toBe('睡眠');
+        expect(sleep.name).toBe('Sleep');
         expect(sleep.type).toBe('status_ailment');
         expect(sleep.effects.cannotAct).toBe(true);
         expect(sleep.effects.defense).toBe(-3);
@@ -76,7 +76,7 @@ describe('StatusAilmentFactory', () => {
       test('デフォルト値で攻撃力アップバフを生成する', () => {
         const buff = StatusAilmentFactory.createAttackBoost();
 
-        expect(buff.name).toBe('攻撃力アップ');
+        expect(buff.name).toBe('Attack Up');
         expect(buff.type).toBe('buff');
         expect(buff.effects.attack).toBe(5); // デフォルトブースト
         expect(buff.duration).toBe(3); // デフォルト継続期間
@@ -102,7 +102,7 @@ describe('StatusAilmentFactory', () => {
       test('デフォルト値で防御力アップバフを生成する', () => {
         const buff = StatusAilmentFactory.createDefenseBoost();
 
-        expect(buff.name).toBe('防御力アップ');
+        expect(buff.name).toBe('Defense Up');
         expect(buff.type).toBe('buff');
         expect(buff.effects.defense).toBe(5);
         expect(buff.duration).toBe(3);
@@ -115,7 +115,7 @@ describe('StatusAilmentFactory', () => {
       test('デフォルト値で再生効果を生成する', () => {
         const regen = StatusAilmentFactory.createRegeneration();
 
-        expect(regen.name).toBe('再生');
+        expect(regen.name).toBe('Regeneration');
         expect(regen.type).toBe('buff');
         expect(regen.effects.hpPerTurn).toBe(5); // デフォルト回復量
         expect(regen.duration).toBe(5); // デフォルト継続期間
@@ -143,7 +143,7 @@ describe('StatusAilmentFactory', () => {
       test('デフォルト値で全ステータスダウンデバフを生成する', () => {
         const debuff = StatusAilmentFactory.createAllStatsDown();
 
-        expect(debuff.name).toBe('全能力ダウン');
+        expect(debuff.name).toBe('All Stats Down');
         expect(debuff.type).toBe('debuff');
         expect(debuff.effects.attack).toBe(-2);
         expect(debuff.effects.defense).toBe(-2);

--- a/src/player/StatusAilmentFactory.test.ts
+++ b/src/player/StatusAilmentFactory.test.ts
@@ -1,0 +1,214 @@
+import { StatusAilmentFactory } from './StatusAilmentFactory';
+import { TemporaryStatus } from './TemporaryStatus';
+
+describe('StatusAilmentFactory', () => {
+  describe('状態異常の生成', () => {
+    describe('createPoison', () => {
+      test('デフォルト値で毒状態異常を生成する', () => {
+        const poison = StatusAilmentFactory.createPoison();
+
+        expect(poison.name).toBe('毒');
+        expect(poison.type).toBe('status_ailment');
+        expect(poison.effects.hpPerTurn).toBe(-3); // デフォルトダメージ
+        expect(poison.effects.cannotRun).toBe(true);
+        expect(poison.duration).toBe(3); // デフォルト継続期間
+        expect(poison.stackable).toBe(false);
+        expect(poison.id).toContain('poison-');
+      });
+
+      test('カスタム値で毒状態異常を生成する', () => {
+        const poison = StatusAilmentFactory.createPoison(5, 7);
+
+        expect(poison.effects.hpPerTurn).toBe(-7); // カスタムダメージ
+        expect(poison.duration).toBe(5); // カスタム継続期間
+      });
+
+      test('正の値を渡してもダメージは負の値になる', () => {
+        const poison = StatusAilmentFactory.createPoison(3, 5);
+
+        expect(poison.effects.hpPerTurn).toBe(-5); // 正の値を渡しても負になる
+      });
+    });
+
+    describe('createParalysis', () => {
+      test('デフォルト値で麻痺状態異常を生成する', () => {
+        const paralysis = StatusAilmentFactory.createParalysis();
+
+        expect(paralysis.name).toBe('麻痺');
+        expect(paralysis.type).toBe('status_ailment');
+        expect(paralysis.effects.cannotAct).toBe(true);
+        expect(paralysis.effects.speed).toBe(-5);
+        expect(paralysis.duration).toBe(2); // デフォルト継続期間
+        expect(paralysis.stackable).toBe(false);
+        expect(paralysis.id).toContain('paralysis-');
+      });
+
+      test('カスタム継続期間で麻痺状態異常を生成する', () => {
+        const paralysis = StatusAilmentFactory.createParalysis(4);
+
+        expect(paralysis.duration).toBe(4);
+      });
+    });
+
+    describe('createSleep', () => {
+      test('デフォルト値で睡眠状態異常を生成する', () => {
+        const sleep = StatusAilmentFactory.createSleep();
+
+        expect(sleep.name).toBe('睡眠');
+        expect(sleep.type).toBe('status_ailment');
+        expect(sleep.effects.cannotAct).toBe(true);
+        expect(sleep.effects.defense).toBe(-3);
+        expect(sleep.duration).toBe(2); // デフォルト継続期間
+        expect(sleep.stackable).toBe(false);
+        expect(sleep.id).toContain('sleep-');
+      });
+
+      test('カスタム継続期間で睡眠状態異常を生成する', () => {
+        const sleep = StatusAilmentFactory.createSleep(3);
+
+        expect(sleep.duration).toBe(3);
+      });
+    });
+  });
+
+  describe('バフの生成', () => {
+    describe('createAttackBoost', () => {
+      test('デフォルト値で攻撃力アップバフを生成する', () => {
+        const buff = StatusAilmentFactory.createAttackBoost();
+
+        expect(buff.name).toBe('攻撃力アップ');
+        expect(buff.type).toBe('buff');
+        expect(buff.effects.attack).toBe(5); // デフォルトブースト
+        expect(buff.duration).toBe(3); // デフォルト継続期間
+        expect(buff.stackable).toBe(true);
+        expect(buff.id).toContain('attack-boost-');
+      });
+
+      test('カスタム値で攻撃力アップバフを生成する', () => {
+        const buff = StatusAilmentFactory.createAttackBoost(4, 8);
+
+        expect(buff.effects.attack).toBe(8);
+        expect(buff.duration).toBe(4);
+      });
+
+      test('負の値を渡しても効果は正の値になる', () => {
+        const buff = StatusAilmentFactory.createAttackBoost(3, -10);
+
+        expect(buff.effects.attack).toBe(10); // 負の値を渡しても正になる
+      });
+    });
+
+    describe('createDefenseBoost', () => {
+      test('デフォルト値で防御力アップバフを生成する', () => {
+        const buff = StatusAilmentFactory.createDefenseBoost();
+
+        expect(buff.name).toBe('防御力アップ');
+        expect(buff.type).toBe('buff');
+        expect(buff.effects.defense).toBe(5);
+        expect(buff.duration).toBe(3);
+        expect(buff.stackable).toBe(true);
+        expect(buff.id).toContain('defense-boost-');
+      });
+    });
+
+    describe('createRegeneration', () => {
+      test('デフォルト値で再生効果を生成する', () => {
+        const regen = StatusAilmentFactory.createRegeneration();
+
+        expect(regen.name).toBe('再生');
+        expect(regen.type).toBe('buff');
+        expect(regen.effects.hpPerTurn).toBe(5); // デフォルト回復量
+        expect(regen.duration).toBe(5); // デフォルト継続期間
+        expect(regen.stackable).toBe(false);
+        expect(regen.id).toContain('regeneration-');
+      });
+
+      test('カスタム値で再生効果を生成する', () => {
+        const regen = StatusAilmentFactory.createRegeneration(3, 8);
+
+        expect(regen.effects.hpPerTurn).toBe(8);
+        expect(regen.duration).toBe(3);
+      });
+
+      test('負の値を渡しても回復量は正の値になる', () => {
+        const regen = StatusAilmentFactory.createRegeneration(3, -7);
+
+        expect(regen.effects.hpPerTurn).toBe(7); // 負の値を渡しても正になる
+      });
+    });
+  });
+
+  describe('デバフの生成', () => {
+    describe('createAllStatsDown', () => {
+      test('デフォルト値で全ステータスダウンデバフを生成する', () => {
+        const debuff = StatusAilmentFactory.createAllStatsDown();
+
+        expect(debuff.name).toBe('全能力ダウン');
+        expect(debuff.type).toBe('debuff');
+        expect(debuff.effects.attack).toBe(-2);
+        expect(debuff.effects.defense).toBe(-2);
+        expect(debuff.effects.speed).toBe(-2);
+        expect(debuff.effects.accuracy).toBe(-2);
+        expect(debuff.effects.fortune).toBe(-2);
+        expect(debuff.duration).toBe(2);
+        expect(debuff.stackable).toBe(false);
+        expect(debuff.id).toContain('all-stats-down-');
+      });
+
+      test('カスタム値で全ステータスダウンデバフを生成する', () => {
+        const debuff = StatusAilmentFactory.createAllStatsDown(3, 4);
+
+        expect(debuff.effects.attack).toBe(-4);
+        expect(debuff.duration).toBe(3);
+      });
+
+      test('負の値を渡してもペナルティは負の値になる', () => {
+        const debuff = StatusAilmentFactory.createAllStatsDown(2, -3);
+
+        expect(debuff.effects.attack).toBe(-3); // 絶対値を取って負にする
+      });
+    });
+  });
+
+  describe('ID の一意性', () => {
+    test('同じファクトリーメソッドを複数回呼び出すと異なるIDが生成される', () => {
+      const poison1 = StatusAilmentFactory.createPoison();
+      const poison2 = StatusAilmentFactory.createPoison();
+
+      expect(poison1.id).not.toBe(poison2.id);
+    });
+
+    test('異なるファクトリーメソッドで異なるIDプレフィックスが使用される', () => {
+      const poison = StatusAilmentFactory.createPoison();
+      const paralysis = StatusAilmentFactory.createParalysis();
+      const buff = StatusAilmentFactory.createAttackBoost();
+
+      expect(poison.id).toContain('poison-');
+      expect(paralysis.id).toContain('paralysis-');
+      expect(buff.id).toContain('attack-boost-');
+    });
+  });
+
+  describe('TemporaryStatus型の適合性', () => {
+    test('生成されたすべてのステータスはTemporaryStatus型に適合する', () => {
+      const statuses: TemporaryStatus[] = [
+        StatusAilmentFactory.createPoison(),
+        StatusAilmentFactory.createParalysis(),
+        StatusAilmentFactory.createSleep(),
+        StatusAilmentFactory.createAttackBoost(),
+        StatusAilmentFactory.createDefenseBoost(),
+        StatusAilmentFactory.createAllStatsDown(),
+        StatusAilmentFactory.createRegeneration(),
+      ];
+
+      statuses.forEach(status => {
+        expect(typeof status.id).toBe('string');
+        expect(typeof status.name).toBe('string');
+        expect(['buff', 'debuff', 'status_ailment']).toContain(status.type);
+        expect(typeof status.effects).toBe('object');
+        expect(typeof status.duration).toBe('number');
+        expect(typeof status.stackable).toBe('boolean');
+      });
+    });
+  });
+});

--- a/src/player/StatusAilmentFactory.ts
+++ b/src/player/StatusAilmentFactory.ts
@@ -1,0 +1,146 @@
+import { TemporaryStatus } from './TemporaryStatus';
+
+/**
+ * 状態異常を生成するファクトリークラス
+ * 標準的な状態異常のプリセットを提供する
+ */
+export class StatusAilmentFactory {
+  /**
+   * 毒状態異常を生成する
+   * @param duration - 継続期間（ターン数）
+   * @param damage - 毎ターンのダメージ量
+   * @returns 毒の一時ステータス
+   */
+  static createPoison(duration: number = 3, damage: number = 3): TemporaryStatus {
+    return {
+      id: `poison-${Date.now()}-${Math.random()}`,
+      name: '毒',
+      type: 'status_ailment',
+      effects: {
+        hpPerTurn: -Math.abs(damage), // ダメージは負の値
+        cannotRun: true, // 毒状態では逃走できない
+      },
+      duration,
+      stackable: false, // 毒は重複しない
+    };
+  }
+
+  /**
+   * 麻痺状態異常を生成する
+   * @param duration - 継続期間（ターン数）
+   * @returns 麻痺の一時ステータス
+   */
+  static createParalysis(duration: number = 2): TemporaryStatus {
+    return {
+      id: `paralysis-${Date.now()}-${Math.random()}`,
+      name: '麻痺',
+      type: 'status_ailment',
+      effects: {
+        cannotAct: true, // 行動不能
+        speed: -5, // 速度低下
+      },
+      duration,
+      stackable: false, // 麻痺は重複しない
+    };
+  }
+
+  /**
+   * 睡眠状態異常を生成する
+   * @param duration - 継続期間（ターン数）
+   * @returns 睡眠の一時ステータス
+   */
+  static createSleep(duration: number = 2): TemporaryStatus {
+    return {
+      id: `sleep-${Date.now()}-${Math.random()}`,
+      name: '睡眠',
+      type: 'status_ailment',
+      effects: {
+        cannotAct: true, // 行動不能
+        defense: -3, // 防御力低下（無防備）
+      },
+      duration,
+      stackable: false, // 睡眠は重複しない
+    };
+  }
+
+  /**
+   * 攻撃力アップバフを生成する
+   * @param duration - 継続期間（ターン数）
+   * @param boost - 攻撃力の増加量
+   * @returns 攻撃力アップの一時ステータス
+   */
+  static createAttackBoost(duration: number = 3, boost: number = 5): TemporaryStatus {
+    return {
+      id: `attack-boost-${Date.now()}-${Math.random()}`,
+      name: '攻撃力アップ',
+      type: 'buff',
+      effects: {
+        attack: Math.abs(boost), // 正の値にする
+      },
+      duration,
+      stackable: true, // バフは重複可能
+    };
+  }
+
+  /**
+   * 防御力アップバフを生成する
+   * @param duration - 継続期間（ターン数）
+   * @param boost - 防御力の増加量
+   * @returns 防御力アップの一時ステータス
+   */
+  static createDefenseBoost(duration: number = 3, boost: number = 5): TemporaryStatus {
+    return {
+      id: `defense-boost-${Date.now()}-${Math.random()}`,
+      name: '防御力アップ',
+      type: 'buff',
+      effects: {
+        defense: Math.abs(boost), // 正の値にする
+      },
+      duration,
+      stackable: true, // バフは重複可能
+    };
+  }
+
+  /**
+   * 全ステータスダウンデバフを生成する
+   * @param duration - 継続期間（ターン数）
+   * @param penalty - ステータスの減少量
+   * @returns 全ステータスダウンの一時ステータス
+   */
+  static createAllStatsDown(duration: number = 2, penalty: number = 2): TemporaryStatus {
+    const abspenalty = Math.abs(penalty);
+    return {
+      id: `all-stats-down-${Date.now()}-${Math.random()}`,
+      name: '全能力ダウン',
+      type: 'debuff',
+      effects: {
+        attack: -abspenalty,
+        defense: -abspenalty,
+        speed: -abspenalty,
+        accuracy: -abspenalty,
+        fortune: -abspenalty,
+      },
+      duration,
+      stackable: false, // デバフは重複しない
+    };
+  }
+
+  /**
+   * 再生効果を生成する
+   * @param duration - 継続期間（ターン数）
+   * @param healAmount - 毎ターンの回復量
+   * @returns 再生の一時ステータス
+   */
+  static createRegeneration(duration: number = 5, healAmount: number = 5): TemporaryStatus {
+    return {
+      id: `regeneration-${Date.now()}-${Math.random()}`,
+      name: '再生',
+      type: 'buff',
+      effects: {
+        hpPerTurn: Math.abs(healAmount), // 正の値にする
+      },
+      duration,
+      stackable: false, // 再生は重複しない
+    };
+  }
+}

--- a/src/player/StatusAilmentFactory.ts
+++ b/src/player/StatusAilmentFactory.ts
@@ -1,4 +1,5 @@
 import { TemporaryStatus, TemporaryStatusName } from './TemporaryStatus';
+import { randomUUID } from 'crypto';
 
 /**
  * 状態異常を生成するファクトリークラス
@@ -13,7 +14,7 @@ export class StatusAilmentFactory {
    */
   static createPoison(duration: number = 3, damage: number = 3): TemporaryStatus {
     return {
-      id: `poison-${Date.now()}-${Math.random()}`,
+      id: `poison-${randomUUID()}`,
       name: 'Poison' as TemporaryStatusName,
       type: 'status_ailment',
       effects: {
@@ -32,7 +33,7 @@ export class StatusAilmentFactory {
    */
   static createParalysis(duration: number = 2): TemporaryStatus {
     return {
-      id: `paralysis-${Date.now()}-${Math.random()}`,
+      id: `paralysis-${randomUUID()}`,
       name: 'Paralysis' as TemporaryStatusName,
       type: 'status_ailment',
       effects: {
@@ -51,7 +52,7 @@ export class StatusAilmentFactory {
    */
   static createSleep(duration: number = 2): TemporaryStatus {
     return {
-      id: `sleep-${Date.now()}-${Math.random()}`,
+      id: `sleep-${randomUUID()}`,
       name: 'Sleep' as TemporaryStatusName,
       type: 'status_ailment',
       effects: {
@@ -71,7 +72,7 @@ export class StatusAilmentFactory {
    */
   static createAttackBoost(duration: number = 3, boost: number = 5): TemporaryStatus {
     return {
-      id: `attack-boost-${Date.now()}-${Math.random()}`,
+      id: `attack-boost-${randomUUID()}`,
       name: 'Attack Up' as TemporaryStatusName,
       type: 'buff',
       effects: {
@@ -90,7 +91,7 @@ export class StatusAilmentFactory {
    */
   static createDefenseBoost(duration: number = 3, boost: number = 5): TemporaryStatus {
     return {
-      id: `defense-boost-${Date.now()}-${Math.random()}`,
+      id: `defense-boost-${randomUUID()}`,
       name: 'Defense Up' as TemporaryStatusName,
       type: 'buff',
       effects: {
@@ -110,7 +111,7 @@ export class StatusAilmentFactory {
   static createAllStatsDown(duration: number = 2, penalty: number = 2): TemporaryStatus {
     const abspenalty = Math.abs(penalty);
     return {
-      id: `all-stats-down-${Date.now()}-${Math.random()}`,
+      id: `all-stats-down-${randomUUID()}`,
       name: 'All Stats Down' as TemporaryStatusName,
       type: 'debuff',
       effects: {
@@ -133,7 +134,7 @@ export class StatusAilmentFactory {
    */
   static createRegeneration(duration: number = 5, healAmount: number = 5): TemporaryStatus {
     return {
-      id: `regeneration-${Date.now()}-${Math.random()}`,
+      id: `regeneration-${randomUUID()}`,
       name: 'Regeneration' as TemporaryStatusName,
       type: 'buff',
       effects: {

--- a/src/player/StatusAilmentFactory.ts
+++ b/src/player/StatusAilmentFactory.ts
@@ -1,4 +1,4 @@
-import { TemporaryStatus } from './TemporaryStatus';
+import { TemporaryStatus, TemporaryStatusName } from './TemporaryStatus';
 
 /**
  * 状態異常を生成するファクトリークラス
@@ -14,7 +14,7 @@ export class StatusAilmentFactory {
   static createPoison(duration: number = 3, damage: number = 3): TemporaryStatus {
     return {
       id: `poison-${Date.now()}-${Math.random()}`,
-      name: '毒',
+      name: 'Poison' as TemporaryStatusName,
       type: 'status_ailment',
       effects: {
         hpPerTurn: -Math.abs(damage), // ダメージは負の値
@@ -33,7 +33,7 @@ export class StatusAilmentFactory {
   static createParalysis(duration: number = 2): TemporaryStatus {
     return {
       id: `paralysis-${Date.now()}-${Math.random()}`,
-      name: '麻痺',
+      name: 'Paralysis' as TemporaryStatusName,
       type: 'status_ailment',
       effects: {
         cannotAct: true, // 行動不能
@@ -52,7 +52,7 @@ export class StatusAilmentFactory {
   static createSleep(duration: number = 2): TemporaryStatus {
     return {
       id: `sleep-${Date.now()}-${Math.random()}`,
-      name: '睡眠',
+      name: 'Sleep' as TemporaryStatusName,
       type: 'status_ailment',
       effects: {
         cannotAct: true, // 行動不能
@@ -72,7 +72,7 @@ export class StatusAilmentFactory {
   static createAttackBoost(duration: number = 3, boost: number = 5): TemporaryStatus {
     return {
       id: `attack-boost-${Date.now()}-${Math.random()}`,
-      name: '攻撃力アップ',
+      name: 'Attack Up' as TemporaryStatusName,
       type: 'buff',
       effects: {
         attack: Math.abs(boost), // 正の値にする
@@ -91,7 +91,7 @@ export class StatusAilmentFactory {
   static createDefenseBoost(duration: number = 3, boost: number = 5): TemporaryStatus {
     return {
       id: `defense-boost-${Date.now()}-${Math.random()}`,
-      name: '防御力アップ',
+      name: 'Defense Up' as TemporaryStatusName,
       type: 'buff',
       effects: {
         defense: Math.abs(boost), // 正の値にする
@@ -111,7 +111,7 @@ export class StatusAilmentFactory {
     const abspenalty = Math.abs(penalty);
     return {
       id: `all-stats-down-${Date.now()}-${Math.random()}`,
-      name: '全能力ダウン',
+      name: 'All Stats Down' as TemporaryStatusName,
       type: 'debuff',
       effects: {
         attack: -abspenalty,
@@ -134,7 +134,7 @@ export class StatusAilmentFactory {
   static createRegeneration(duration: number = 5, healAmount: number = 5): TemporaryStatus {
     return {
       id: `regeneration-${Date.now()}-${Math.random()}`,
-      name: '再生',
+      name: 'Regeneration' as TemporaryStatusName,
       type: 'buff',
       effects: {
         hpPerTurn: Math.abs(healAmount), // 正の値にする

--- a/src/player/TemporaryStatus.test.ts
+++ b/src/player/TemporaryStatus.test.ts
@@ -5,7 +5,7 @@ describe('TemporaryStatus', () => {
     test('TemporaryStatusオブジェクトの基本プロパティが正しく設定される', () => {
       const status: TemporaryStatus = {
         id: 'buff-attack-001',
-        name: '攻撃力アップ',
+        name: 'Attack Up',
         type: 'buff',
         effects: {
           attack: 10,
@@ -15,7 +15,7 @@ describe('TemporaryStatus', () => {
       };
 
       expect(status.id).toBe('buff-attack-001');
-      expect(status.name).toBe('攻撃力アップ');
+      expect(status.name).toBe('Attack Up');
       expect(status.type).toBe('buff');
       expect(status.effects.attack).toBe(10);
       expect(status.duration).toBe(3);
@@ -25,7 +25,7 @@ describe('TemporaryStatus', () => {
     test('複数の効果を持つTemporaryStatusが正しく定義される', () => {
       const status: TemporaryStatus = {
         id: 'buff-multi-001',
-        name: '全能力アップ',
+        name: 'All Stats Up',
         type: 'buff',
         effects: {
           attack: 5,
@@ -49,7 +49,7 @@ describe('TemporaryStatus', () => {
     test('デバフ効果が正しく定義される', () => {
       const status: TemporaryStatus = {
         id: 'debuff-attack-001',
-        name: '攻撃力ダウン',
+        name: 'Attack Down',
         type: 'debuff',
         effects: {
           attack: -5,
@@ -65,7 +65,7 @@ describe('TemporaryStatus', () => {
     test('状態異常が正しく定義される', () => {
       const status: TemporaryStatus = {
         id: 'poison-001',
-        name: '毒',
+        name: 'Poison',
         type: 'status_ailment',
         effects: {
           hpPerTurn: -3,
@@ -83,7 +83,7 @@ describe('TemporaryStatus', () => {
     test('永続効果（duration: -1）が正しく設定される', () => {
       const status: TemporaryStatus = {
         id: 'permanent-001',
-        name: '永続ブースト',
+        name: 'Attack Up',
         type: 'buff',
         effects: {
           attack: 1,
@@ -100,7 +100,7 @@ describe('TemporaryStatus', () => {
     test('すべてのステータス効果が正しく定義される', () => {
       const status: TemporaryStatus = {
         id: 'test-all-effects',
-        name: 'テスト用効果',
+        name: 'All Stats Up',
         type: 'buff',
         effects: {
           attack: 1,
@@ -141,7 +141,7 @@ describe('TemporaryStatus', () => {
     test('TemporaryStatusがJSONに正しく変換される', () => {
       const status: TemporaryStatus = {
         id: 'test-serialize',
-        name: 'シリアライズテスト',
+        name: 'Attack Up',
         type: 'buff',
         effects: {
           attack: 10,
@@ -155,7 +155,7 @@ describe('TemporaryStatus', () => {
       const parsed = JSON.parse(json);
 
       expect(parsed.id).toBe('test-serialize');
-      expect(parsed.name).toBe('シリアライズテスト');
+      expect(parsed.name).toBe('Attack Up');
       expect(parsed.type).toBe('buff');
       expect(parsed.effects.attack).toBe(10);
       expect(parsed.effects.defense).toBe(5);
@@ -166,7 +166,7 @@ describe('TemporaryStatus', () => {
     test('JSONからTemporaryStatusが正しく復元される', () => {
       const data: TemporaryStatusData = {
         id: 'test-deserialize',
-        name: 'デシリアライズテスト',
+        name: 'Speed Down',
         type: 'debuff',
         effects: {
           speed: -3,
@@ -180,7 +180,7 @@ describe('TemporaryStatus', () => {
       const parsed: TemporaryStatus = JSON.parse(json);
 
       expect(parsed.id).toBe('test-deserialize');
-      expect(parsed.name).toBe('デシリアライズテスト');
+      expect(parsed.name).toBe('Speed Down');
       expect(parsed.type).toBe('debuff');
       expect(parsed.effects.speed).toBe(-3);
       expect(parsed.effects.cannotAct).toBe(true);
@@ -191,7 +191,7 @@ describe('TemporaryStatus', () => {
     test('部分的な効果を持つTemporaryStatusがJSONで正しく扱われる', () => {
       const status: TemporaryStatus = {
         id: 'partial-effects',
-        name: '部分効果',
+        name: 'Poison',
         type: 'status_ailment',
         effects: {
           hpPerTurn: -1,

--- a/src/player/TemporaryStatus.test.ts
+++ b/src/player/TemporaryStatus.test.ts
@@ -1,4 +1,4 @@
-import { TemporaryStatus, TemporaryStatusData, TemporaryStatusType } from './TemporaryStatus';
+import { TemporaryStatus, TemporaryStatusType } from './TemporaryStatus';
 
 describe('TemporaryStatus', () => {
   describe('TemporaryStatusの基本プロパティ', () => {
@@ -164,7 +164,7 @@ describe('TemporaryStatus', () => {
     });
 
     test('JSONからTemporaryStatusが正しく復元される', () => {
-      const data: TemporaryStatusData = {
+      const data: TemporaryStatus = {
         id: 'test-deserialize',
         name: 'Speed Down',
         type: 'debuff',

--- a/src/player/TemporaryStatus.test.ts
+++ b/src/player/TemporaryStatus.test.ts
@@ -1,0 +1,212 @@
+import { TemporaryStatus, TemporaryStatusData, TemporaryStatusType } from './TemporaryStatus';
+
+describe('TemporaryStatus', () => {
+  describe('TemporaryStatusの基本プロパティ', () => {
+    test('TemporaryStatusオブジェクトの基本プロパティが正しく設定される', () => {
+      const status: TemporaryStatus = {
+        id: 'buff-attack-001',
+        name: '攻撃力アップ',
+        type: 'buff',
+        effects: {
+          attack: 10,
+        },
+        duration: 3,
+        stackable: false,
+      };
+
+      expect(status.id).toBe('buff-attack-001');
+      expect(status.name).toBe('攻撃力アップ');
+      expect(status.type).toBe('buff');
+      expect(status.effects.attack).toBe(10);
+      expect(status.duration).toBe(3);
+      expect(status.stackable).toBe(false);
+    });
+
+    test('複数の効果を持つTemporaryStatusが正しく定義される', () => {
+      const status: TemporaryStatus = {
+        id: 'buff-multi-001',
+        name: '全能力アップ',
+        type: 'buff',
+        effects: {
+          attack: 5,
+          defense: 5,
+          speed: 3,
+          accuracy: 3,
+          fortune: 2,
+        },
+        duration: 5,
+        stackable: true,
+      };
+
+      expect(status.effects.attack).toBe(5);
+      expect(status.effects.defense).toBe(5);
+      expect(status.effects.speed).toBe(3);
+      expect(status.effects.accuracy).toBe(3);
+      expect(status.effects.fortune).toBe(2);
+      expect(status.stackable).toBe(true);
+    });
+
+    test('デバフ効果が正しく定義される', () => {
+      const status: TemporaryStatus = {
+        id: 'debuff-attack-001',
+        name: '攻撃力ダウン',
+        type: 'debuff',
+        effects: {
+          attack: -5,
+        },
+        duration: 2,
+        stackable: false,
+      };
+
+      expect(status.type).toBe('debuff');
+      expect(status.effects.attack).toBe(-5);
+    });
+
+    test('状態異常が正しく定義される', () => {
+      const status: TemporaryStatus = {
+        id: 'poison-001',
+        name: '毒',
+        type: 'status_ailment',
+        effects: {
+          hpPerTurn: -3,
+          cannotRun: true,
+        },
+        duration: 3,
+        stackable: false,
+      };
+
+      expect(status.type).toBe('status_ailment');
+      expect(status.effects.hpPerTurn).toBe(-3);
+      expect(status.effects.cannotRun).toBe(true);
+    });
+
+    test('永続効果（duration: -1）が正しく設定される', () => {
+      const status: TemporaryStatus = {
+        id: 'permanent-001',
+        name: '永続ブースト',
+        type: 'buff',
+        effects: {
+          attack: 1,
+        },
+        duration: -1,
+        stackable: true,
+      };
+
+      expect(status.duration).toBe(-1);
+    });
+  });
+
+  describe('効果の型定義テスト', () => {
+    test('すべてのステータス効果が正しく定義される', () => {
+      const status: TemporaryStatus = {
+        id: 'test-all-effects',
+        name: 'テスト用効果',
+        type: 'buff',
+        effects: {
+          attack: 1,
+          defense: 2,
+          speed: 3,
+          accuracy: 4,
+          fortune: 5,
+          hpPerTurn: 1,
+          mpPerTurn: 2,
+          cannotAct: false,
+          cannotRun: false,
+        },
+        duration: 1,
+        stackable: false,
+      };
+
+      expect(typeof status.effects.attack).toBe('number');
+      expect(typeof status.effects.defense).toBe('number');
+      expect(typeof status.effects.speed).toBe('number');
+      expect(typeof status.effects.accuracy).toBe('number');
+      expect(typeof status.effects.fortune).toBe('number');
+      expect(typeof status.effects.hpPerTurn).toBe('number');
+      expect(typeof status.effects.mpPerTurn).toBe('number');
+      expect(typeof status.effects.cannotAct).toBe('boolean');
+      expect(typeof status.effects.cannotRun).toBe('boolean');
+    });
+
+    test('TemporaryStatusType列挙型が正しく定義される', () => {
+      const types: TemporaryStatusType[] = ['buff', 'debuff', 'status_ailment'];
+
+      expect(types).toContain('buff');
+      expect(types).toContain('debuff');
+      expect(types).toContain('status_ailment');
+    });
+  });
+
+  describe('JSON シリアライゼーションテスト', () => {
+    test('TemporaryStatusがJSONに正しく変換される', () => {
+      const status: TemporaryStatus = {
+        id: 'test-serialize',
+        name: 'シリアライズテスト',
+        type: 'buff',
+        effects: {
+          attack: 10,
+          defense: 5,
+        },
+        duration: 3,
+        stackable: true,
+      };
+
+      const json = JSON.stringify(status);
+      const parsed = JSON.parse(json);
+
+      expect(parsed.id).toBe('test-serialize');
+      expect(parsed.name).toBe('シリアライズテスト');
+      expect(parsed.type).toBe('buff');
+      expect(parsed.effects.attack).toBe(10);
+      expect(parsed.effects.defense).toBe(5);
+      expect(parsed.duration).toBe(3);
+      expect(parsed.stackable).toBe(true);
+    });
+
+    test('JSONからTemporaryStatusが正しく復元される', () => {
+      const data: TemporaryStatusData = {
+        id: 'test-deserialize',
+        name: 'デシリアライズテスト',
+        type: 'debuff',
+        effects: {
+          speed: -3,
+          cannotAct: true,
+        },
+        duration: 2,
+        stackable: false,
+      };
+
+      const json = JSON.stringify(data);
+      const parsed: TemporaryStatus = JSON.parse(json);
+
+      expect(parsed.id).toBe('test-deserialize');
+      expect(parsed.name).toBe('デシリアライズテスト');
+      expect(parsed.type).toBe('debuff');
+      expect(parsed.effects.speed).toBe(-3);
+      expect(parsed.effects.cannotAct).toBe(true);
+      expect(parsed.duration).toBe(2);
+      expect(parsed.stackable).toBe(false);
+    });
+
+    test('部分的な効果を持つTemporaryStatusがJSONで正しく扱われる', () => {
+      const status: TemporaryStatus = {
+        id: 'partial-effects',
+        name: '部分効果',
+        type: 'status_ailment',
+        effects: {
+          hpPerTurn: -1,
+        }, // 他の効果は undefined
+        duration: 5,
+        stackable: false,
+      };
+
+      const json = JSON.stringify(status);
+      const parsed: TemporaryStatus = JSON.parse(json);
+
+      expect(parsed.effects.hpPerTurn).toBe(-1);
+      expect(parsed.effects.attack).toBeUndefined();
+      expect(parsed.effects.defense).toBeUndefined();
+      expect(parsed.effects.cannotAct).toBeUndefined();
+    });
+  });
+});

--- a/src/player/TemporaryStatus.ts
+++ b/src/player/TemporaryStatus.ts
@@ -1,0 +1,60 @@
+/**
+ * 一時ステータスの種別
+ */
+export type TemporaryStatusType = 'buff' | 'debuff' | 'status_ailment';
+
+/**
+ * 一時ステータスの効果
+ */
+export interface TemporaryStatusEffects {
+  /** 攻撃力増減値 */
+  attack?: number;
+  /** 防御力増減値 */
+  defense?: number;
+  /** 速度増減値 */
+  speed?: number;
+  /** 命中率増減値 */
+  accuracy?: number;
+  /** 幸運増減値 */
+  fortune?: number;
+  /** 毎ターンのHP増減（毒などで使用） */
+  hpPerTurn?: number;
+  /** 毎ターンのMP増減 */
+  mpPerTurn?: number;
+  /** 行動不能（麻痺、睡眠） */
+  cannotAct?: boolean;
+  /** 逃走不可 */
+  cannotRun?: boolean;
+}
+
+/**
+ * 一時ステータス
+ * バフ、デバフ、状態異常を統一的に管理するためのインターフェース
+ */
+export interface TemporaryStatus {
+  /** 一意識別子 */
+  id: string;
+  /** 名前（例: "攻撃力アップ", "毒"） */
+  name: string;
+  /** 種別 */
+  type: TemporaryStatusType;
+  /** ステータスへの影響 */
+  effects: TemporaryStatusEffects;
+  /** 残り継続期間（ターン数、-1で永続） */
+  duration: number;
+  /** 同じ効果を重ねがけ可能か */
+  stackable: boolean;
+}
+
+/**
+ * 一時ステータスのJSONデータ構造
+ * TemporaryStatusと同じ構造だが、JSONシリアライゼーション用に明示的に定義
+ */
+export interface TemporaryStatusData {
+  id: string;
+  name: string;
+  type: TemporaryStatusType;
+  effects: TemporaryStatusEffects;
+  duration: number;
+  stackable: boolean;
+}

--- a/src/player/TemporaryStatus.ts
+++ b/src/player/TemporaryStatus.ts
@@ -4,6 +4,33 @@
 export type TemporaryStatusType = 'buff' | 'debuff' | 'status_ailment';
 
 /**
+ * 一時ステータスの名前
+ */
+export type TemporaryStatusName =
+  // Buffs
+  | 'Attack Up'
+  | 'Defense Up'
+  | 'Speed Up'
+  | 'Accuracy Up'
+  | 'Fortune Up'
+  | 'All Stats Up'
+  | 'Regeneration'
+  // Debuffs
+  | 'Attack Down'
+  | 'Defense Down'
+  | 'Speed Down'
+  | 'Accuracy Down'
+  | 'Fortune Down'
+  | 'All Stats Down'
+  // Status Ailments
+  | 'Poison'
+  | 'Paralysis'
+  | 'Sleep'
+  | 'Confusion'
+  | 'Burn'
+  | 'Freeze';
+
+/**
  * 一時ステータスの効果
  */
 export interface TemporaryStatusEffects {
@@ -34,8 +61,8 @@ export interface TemporaryStatusEffects {
 export interface TemporaryStatus {
   /** 一意識別子 */
   id: string;
-  /** 名前（例: "攻撃力アップ", "毒"） */
-  name: string;
+  /** 名前（例: "Attack Up", "Poison"） */
+  name: TemporaryStatusName;
   /** 種別 */
   type: TemporaryStatusType;
   /** ステータスへの影響 */
@@ -52,7 +79,7 @@ export interface TemporaryStatus {
  */
 export interface TemporaryStatusData {
   id: string;
-  name: string;
+  name: TemporaryStatusName;
   type: TemporaryStatusType;
   effects: TemporaryStatusEffects;
   duration: number;

--- a/src/player/TemporaryStatus.ts
+++ b/src/player/TemporaryStatus.ts
@@ -74,14 +74,95 @@ export interface TemporaryStatus {
 }
 
 /**
- * 一時ステータスのJSONデータ構造
- * TemporaryStatusと同じ構造だが、JSONシリアライゼーション用に明示的に定義
+ * オブジェクトがTemporaryStatusEffectsの有効な構造かどうかを検証する
+ * @param obj - 検証するオブジェクト
+ * @returns 有効な場合true
  */
-export interface TemporaryStatusData {
-  id: string;
-  name: TemporaryStatusName;
-  type: TemporaryStatusType;
-  effects: TemporaryStatusEffects;
-  duration: number;
-  stackable: boolean;
+export function isTemporaryStatusEffects(obj: any): obj is TemporaryStatusEffects {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+
+  // 数値プロパティのチェック
+  const numberProps = [
+    'attack',
+    'defense',
+    'speed',
+    'accuracy',
+    'fortune',
+    'hpPerTurn',
+    'mpPerTurn',
+  ];
+  for (const prop of numberProps) {
+    if (obj[prop] !== undefined && typeof obj[prop] !== 'number') {
+      return false;
+    }
+  }
+
+  // 真偽値プロパティのチェック
+  const booleanProps = ['cannotAct', 'cannotRun'];
+  for (const prop of booleanProps) {
+    if (obj[prop] !== undefined && typeof obj[prop] !== 'boolean') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * 有効なTemporaryStatusNameの定数配列
+ */
+const VALID_TEMPORARY_STATUS_NAMES: TemporaryStatusName[] = [
+  'Attack Up',
+  'Defense Up',
+  'Speed Up',
+  'Accuracy Up',
+  'Fortune Up',
+  'All Stats Up',
+  'Regeneration',
+  'Attack Down',
+  'Defense Down',
+  'Speed Down',
+  'Accuracy Down',
+  'Fortune Down',
+  'All Stats Down',
+  'Poison',
+  'Paralysis',
+  'Sleep',
+  'Confusion',
+  'Burn',
+  'Freeze',
+];
+
+/**
+ * 有効なTemporaryStatusTypeの定数配列
+ */
+const VALID_TEMPORARY_STATUS_TYPES: TemporaryStatusType[] = ['buff', 'debuff', 'status_ailment'];
+
+/**
+ * オブジェクトがTemporaryStatusの有効な構造かどうかを検証する
+ * @param obj - 検証するオブジェクト
+ * @returns 有効な場合true
+ */
+export function isTemporaryStatus(obj: any): obj is TemporaryStatus {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+
+  // 必須プロパティのチェック
+  if (typeof obj.id !== 'string') return false;
+  if (typeof obj.name !== 'string') return false;
+  if (typeof obj.type !== 'string') return false;
+  if (typeof obj.duration !== 'number') return false;
+  if (typeof obj.stackable !== 'boolean') return false;
+
+  // 名前が有効なTemporaryStatusNameかチェック
+  if (!VALID_TEMPORARY_STATUS_NAMES.includes(obj.name as TemporaryStatusName)) return false;
+
+  // 種別が有効なTemporaryStatusTypeかチェック
+  if (!VALID_TEMPORARY_STATUS_TYPES.includes(obj.type as TemporaryStatusType)) return false;
+
+  // 効果が有効な構造かチェック
+  return isTemporaryStatusEffects(obj.effects);
 }


### PR DESCRIPTION
## Summary
Statsクラスを拡張して、バフ、デバフ、状態異常を統一的に管理する一時ステータスシステムを実装しました。

- バフ、デバフ、状態異常を「一時ステータス」として統一管理
- 一時ステータスは効果と継続期間を持つ
- プレイヤーは一時ステータスをスタック可能
- 一時ステータスの効果の総和で最終的なステータスを決定
- 状態異常については仮実装として毒、麻痺、睡眠を用意

## 主な変更内容

### 新機能
- **TemporaryStatusインターフェース**: 統一的なステータス管理
- **一時ステータス管理機能**: 追加・削除・取得
- **効果計算システム**: 基本ステータス+一時ステータス効果
- **ターン経過処理**: 継続期間の減少と毎ターン効果の適用
- **StatusAilmentFactory**: 状態異常とバフの生成

### TemporaryStatusインターフェース
- `id`, `name`, `type`, `effects`, `duration`, `stackable`を持つ
- `type`: 'buff' | 'debuff' | 'status_ailment'
- `stackable`: 同名効果の重複可否
- `duration`: -1で永続効果、0以上でターン数

### Statsクラス機能追加
- `addTemporaryStatus()`: 一時ステータス追加
- `removeTemporaryStatus()`: 一時ステータス削除
- `getTemporaryStatuses()`: 全一時ステータス取得
- `getActiveStatusAilments()`: 状態異常のみ取得
- `getTotalStats()`: 一時ステータス効果を含む総合ステータス
- `updateTemporaryStatuses()`: ターン経過処理

### 効果計算の統合
- 既存のgetterメソッド（`getAttack`等）に一時ステータス効果を統合
- 基本ステータス + temporaryBoosts + 一時ステータス効果
- 負の値は0でクランプ

### ターン経過処理
- 毎ターン効果（`hpPerTurn`, `mpPerTurn`）の適用
- 継続期間の自動減少
- 期限切れステータスの自動削除
- 永続効果（duration: -1）のサポート

### StatusAilmentFactory
- 毒、麻痺、睡眠の状態異常プリセット
- 各種バフ・デバフの生成機能
- 一意なIDの自動生成

## Test plan
- [x] 54個の新規テストケースを追加
- [x] 全ての既存テストが継続して動作
- [x] TDD手法による段階的な実装
- [x] `npm run check`でフォーマット、リント、テストがすべて通過
- [x] 型安全性の確保（TypeScript完全対応）
- [x] 後方互換性の維持（既存のStats機能をすべて維持）

## 実装アプローチ
1. **Phase 1**: TemporaryStatusインターフェースの実装
2. **Phase 2**: Statsクラスの拡張（一時ステータス管理）
3. **Phase 3**: 効果計算システムの実装
4. **Phase 4**: ターン経過処理の実装
5. **Phase 5**: 状態異常システムの仮実装
6. **Phase 6**: 統合とリファクタリング

各フェーズでRED → GREEN → REFACTORのTDD手法を採用し、品質の高いコードを段階的に構築しました。

🤖 Generated with [Claude Code](https://claude.ai/code)